### PR TITLE
Release changes ready for centos-6-1.3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 #		--format '{{ .State.Pid }}' mysql.pool-1.1.1) /bin/bash
 #
 # =============================================================================
-FROM jdeathe/centos-ssh:centos-6
+FROM jdeathe/centos-ssh:centos-6-1.3.0
 
 MAINTAINER James Deathe <james.deathe@gmail.com>
 
@@ -21,7 +21,9 @@ MAINTAINER James Deathe <james.deathe@gmail.com>
 # Install MySQL
 # -----------------------------------------------------------------------------
 RUN yum --setopt=tsflags=nodocs -y install \
-	mysql-server \
+	mysql-server-5.1.73-5.el6_6 \
+	&& yum versionlock add \
+	mysql* \
 	; rm -rf /var/cache/yum/* \
 	; yum clean all
 

--- a/README.md
+++ b/README.md
@@ -80,21 +80,12 @@ $ mkdir -p /etc/services-config/mysql.pool-1.1.1
 
 Create the data volume, mounting the applicable docker host's configuration directories to the associated  */etc/services-config/* sub-directories in the docker container. Docker will pull the busybox:latest image if you don't already have it available locally.
 
-```
-$ docker run \
-  --name volume-config.mysql.pool-1.1.1 \
-  -v /etc/services-config/mysql.pool-1.1.1/supervisor:/etc/services-config/supervisor \
-  -v /etc/services-config/mysql.pool-1.1.1/mysql:/etc/services-config/mysql \
-  busybox:latest \
-  /bin/true
-```
-
 If enabling the SSH service in the supervisor configuration you can define a persistent authorised key for SSH access by mounting the ssh.pool-1 directory and adding the key there.
 
 ```
 $ docker run \
   --name volume-config.mysql.pool-1.1.1 \
-  -v /etc/services-config/ssh.pool-1:/etc/services-config/ssh \
+  -v /etc/services-config/ssh.pool-1/ssh:/etc/services-config/ssh \
   -v /etc/services-config/mysql.pool-1.1.1/supervisor:/etc/services-config/supervisor \
   -v /etc/services-config/mysql.pool-1.1.1/mysql:/etc/services-config/mysql \
   busybox:latest \

--- a/build.sh
+++ b/build.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 # Change working directory
-DIR_PATH="$( cd "$( echo "${0%/*}" )"; pwd )"
-if [[ $DIR_PATH == */* ]]; then
+DIR_PATH="$( if [ "$( echo "${0%/*}" )" != "$( echo "${0}" )" ] ; then cd "$( echo "${0%/*}" )"; fi; pwd )"
+if [[ $DIR_PATH == */* ]] && [[ $DIR_PATH != "$( pwd )" ]] ; then
 	cd $DIR_PATH
 fi
 

--- a/etc/mysql-bootstrap
+++ b/etc/mysql-bootstrap
@@ -17,6 +17,9 @@ get_password ()
 }
 
 OPTS_MYSQL_DATA_DIR=$(get_option mysqld datadir "${MYSQL_DATA_DIR_DEFAULT:-/var/lib/mysql}")
+OPTS_MYSQL_SOCKET=$(get_option mysqld socket "/var/run/mysqld/mysql.sock")
+OPTS_MYSQL_SOCKET_DIR=${OPTS_MYSQL_SOCKET%/*}
+OPTS_MYSQL_SERVICE_USER=$(get_option mysqld user "mysql")
 OPTS_FORCE_MYSQL_INSTALL=${FORCE_MYSQL_INSTALL:-0}
 OPTS_CUSTOM_MYSQL_INIT_SQL=${CUSTOM_MYSQL_INIT_SQL:-}
 
@@ -27,33 +30,60 @@ fi
 
 if [[ ! -f ${OPTS_MYSQL_DATA_DIR}/ibdata1 ]]; then
 
+	# Adjust the UID/GID values of the service user to match a directory that could be a mounted volume
+	if [ -d ${OPTS_MYSQL_DATA_DIR} ]; then
+		SERVICE_UID=$(stat -c "%u" ${OPTS_MYSQL_DATA_DIR})
+		SERVICE_GID=$(stat -c "%g" ${OPTS_MYSQL_DATA_DIR})
+
+		if [ "$SERVICE_UID" != "" ] && [ "$SERVICE_UID" != "0" ]; then
+			usermod -u ${SERVICE_UID} ${OPTS_MYSQL_SERVICE_USER}
+			chown -R ${OPTS_MYSQL_SERVICE_USER} ${OPTS_MYSQL_SOCKET_DIR:-/var/run/mysqld}
+		fi
+
+		if [ "$SERVICE_GID" != "" ] && [ "$SERVICE_GID" != "0" ]; then
+			groupmod -g ${SERVICE_GID} ${OPTS_MYSQL_SERVICE_USER}
+
+			# If the group already exists add it to the user's supplementary groups
+			if [ ! "$?" -eq "0" ]; then
+				usermod -G ${SERVICE_GID} ${OPTS_MYSQL_SERVICE_USER}
+			fi
+		fi
+	fi
+
 	OPTS_MYSQL_ROOT_PASSWORD="${MYSQL_ROOT_PASSWORD:-$(get_password 8)}"
 
 	# Initialise MySQL Data Directory
-	/usr/bin/mysql_install_db --verbose --force --skip-name-resolve --tmpdir=${OPTS_MYSQL_DATA_DIR}
+	/usr/bin/mysql_install_db --verbose --force --skip-name-resolve --tmpdir=${OPTS_MYSQL_DATA_DIR} &
 
-	# Secure MySQL
-	echo "DELETE FROM mysql.user WHERE User='';" > /tmp/mysql-init
-	echo "DELETE FROM mysql.user WHERE User='root' AND Host NOT IN ('localhost', '127.0.0.1', '::1');" >> /tmp/mysql-init
-	echo "DROP DATABASE IF EXISTS test;" >> /tmp/mysql-init
-	echo "DELETE FROM mysql.db WHERE Db='test' OR Db='test\\_%';" >> /tmp/mysql-init
-	echo "GRANT ALL PRIVILEGES ON *.* TO 'root'@'localhost' IDENTIFIED BY '${OPTS_MYSQL_ROOT_PASSWORD}' WITH GRANT OPTION;" >> /tmp/mysql-init
-	echo "GRANT ALL PRIVILEGES ON *.* TO 'root'@'127.0.0.1' IDENTIFIED BY '${OPTS_MYSQL_ROOT_PASSWORD}' WITH GRANT OPTION;" >> /tmp/mysql-init
-	echo "-- =============================================================================" >> /tmp/mysql-init
-	echo "-- Custom Initialisation SQL start" >> /tmp/mysql-init
-	echo "-- " >> /tmp/mysql-init
-	echo "${OPTS_CUSTOM_MYSQL_INIT_SQL}" >> /tmp/mysql-init
-	echo "-- " >> /tmp/mysql-init
-	echo "-- Custom Initialisation SQL end" >> /tmp/mysql-init
-	echo "-- -----------------------------------------------------------------------------" >> /tmp/mysql-init
-	echo "FLUSH PRIVILEGES;" >> /tmp/mysql-init
+	# Generate the initialisation SQL used secure MySQL
+	cat <<-EOT > /tmp/mysql-init
 
-	echo
-	echo $"Initialisation SQL:\n$(cat /tmp/mysql-init)"
-	
-	echo
+		-- Secure MySQL
+		DELETE FROM mysql.user WHERE User='';
+		DELETE FROM mysql.user WHERE User='root' AND Host NOT IN ('localhost', '127.0.0.1', '::1');
+		DROP DATABASE IF EXISTS test;
+		DELETE FROM mysql.db WHERE Db='test' OR Db='test\\_%';
+		GRANT ALL PRIVILEGES ON *.* TO 'root'@'localhost' IDENTIFIED BY '${OPTS_MYSQL_ROOT_PASSWORD}' WITH GRANT OPTION;
+		GRANT ALL PRIVILEGES ON *.* TO 'root'@'127.0.0.1' IDENTIFIED BY '${OPTS_MYSQL_ROOT_PASSWORD}' WITH GRANT OPTION;
+		-- =============================================================================
+		-- Custom Initialisation SQL start
+		-- 
+		${OPTS_CUSTOM_MYSQL_INIT_SQL}
+		-- 
+		-- Custom Initialisation SQL end
+		-- -----------------------------------------------------------------------------
+		FLUSH PRIVILEGES;
+	EOT
+
+	cat <<-EOT
+		Initialisation SQL:
+		$(cat /tmp/mysql-init)
+	EOT
+
+	# Wait for the MySQL system table installation to complete
+	wait ${!}
+
 	echo "Initialising MySQL..."
-	/etc/init.d/mysqld stop && \
 	/usr/bin/mysqld_safe --init-file=/tmp/mysql-init &
 
 	# Allow some time for the service to start
@@ -62,13 +92,15 @@ if [[ ! -f ${OPTS_MYSQL_DATA_DIR}/ibdata1 ]]; then
 	echo "Stopping MySQL..."
 	killall -15 mysqld
 
-	echo
-	echo "================================================================================"
-	echo "MySQL Credentials"
-	echo "--------------------------------------------------------------------------------"
-	echo "root@localhost : ${OPTS_MYSQL_ROOT_PASSWORD}"
-	echo "--------------------------------------------------------------------------------"
-	echo
+	cat <<-EOT
+
+		================================================================================
+		MySQL Credentials
+		--------------------------------------------------------------------------------
+		root@localhost : ${OPTS_MYSQL_ROOT_PASSWORD}
+		--------------------------------------------------------------------------------
+		
+	EOT
 
 	# Wait for the MySQL daemon to stop
 	wait ${!}

--- a/etc/services-config/mysql/my.cnf
+++ b/etc/services-config/mysql/my.cnf
@@ -1,9 +1,10 @@
 [client]
+socket=/var/run/mysqld/mysql.sock
 default-character-set=utf8
 
 [mysqld]
 datadir=/var/lib/mysql
-socket=/var/lib/mysql/mysql.sock
+socket=/var/run/mysqld/mysql.sock
 user=mysql
 # Disabling symbolic-links is recommended to prevent assorted security risks
 symbolic-links=0

--- a/etc/services-config/mysql/my.cnf
+++ b/etc/services-config/mysql/my.cnf
@@ -9,7 +9,7 @@ user=mysql
 symbolic-links=0
 
 skip-character-set-client-handshake=1
-default-character-set=utf8
+character-set-server=utf8
 collation-server=utf8_unicode_ci
 
 #log-queries-not-using-indexes=1

--- a/etc/services-config/supervisor/supervisord.conf
+++ b/etc/services-config/supervisor/supervisord.conf
@@ -37,7 +37,7 @@ stdout_events_enabled = true
 
 [program:mysqld_safe]
 priority = 100
-command = /usr/bin/pidproxy /var/run/mysqld/mysqld.pid /usr/bin/mysqld_safe
+command = /bin/bash -c "/bin/sleep 2 && /usr/bin/pidproxy /var/run/mysqld/mysqld.pid /usr/bin/mysqld_safe"
 redirect_stderr = true
 stdout_logfile = /var/log/mysqld.log
 stdout_events_enabled = true

--- a/mysql.pool-1.1.1@3306.service
+++ b/mysql.pool-1.1.1@3306.service
@@ -45,10 +45,10 @@ ExecStartPre=/bin/sudo /bin/bash -c \
 # Initialisation: Pull or build image if required
 ExecStartPre=/bin/sudo /bin/bash -c \
   "if [ ! \"jdeathe/centos-ssh-mysql\" == \"$(/usr/bin/docker images | /bin/grep -e '^jdeathe/centos-ssh-mysql[ ]\{1,\}' | /bin/grep -o 'jdeathe/centos-ssh-mysql')\" ]; then \
-    if [ -f /var/services-packages/jdeathe/centos-ssh-mysql.centos-6-1.2.2.tar.xz ]; then \
-      /usr/bin/xz -dc /var/services-packages/jdeathe/centos-ssh-mysql.centos-6-1.2.2.tar.xz | /usr/bin/docker load; \
+    if [ -f /var/services-packages/jdeathe/centos-ssh-mysql.centos-6-1.3.0.tar.xz ]; then \
+      /usr/bin/xz -dc /var/services-packages/jdeathe/centos-ssh-mysql.centos-6-1.3.0.tar.xz | /usr/bin/docker load; \
     else \
-      /usr/bin/docker pull jdeathe/centos-ssh-mysql:centos-6-1.2.2; \
+      /usr/bin/docker pull jdeathe/centos-ssh-mysql:centos-6-1.3.0; \
     fi; \
   fi"
 
@@ -66,7 +66,7 @@ ExecStart=/bin/sudo /bin/bash -c \
     -p %i:3306 \
     --volumes-from volume-config.%p \
     -v /var/services-data/mysql/pool-1:/var/lib/mysql \
-    jdeathe/centos-ssh-mysql:centos-6-1.2.2"
+    jdeathe/centos-ssh-mysql:centos-6-1.3.0"
 
 ExecStartPost=/usr/bin/etcdctl set /services/mysql/pool-1/1.1 %H:%i
 

--- a/mysql.pool-1.1.1@3306.service
+++ b/mysql.pool-1.1.1@3306.service
@@ -35,7 +35,7 @@ ExecStartPre=/bin/sudo /bin/bash -c \
   if [ ! \"volume-config.%p\" == \"$(/usr/bin/docker ps -a | /bin/grep -v -e \\\"volume-config.%p/.*,.*\\\" | /bin/grep -e '[ ]\{1,\}'volume-config.%p | /bin/grep -o volume-config.%p)\" ]; then \
     /usr/bin/docker run \
       --name volume-config.%p \
-      -v /etc/services-config/ssh.pool-1:/etc/services-config/ssh \
+      -v /etc/services-config/ssh.pool-1/ssh:/etc/services-config/ssh \
       -v /etc/services-config/%p/supervisor:/etc/services-config/supervisor \
       -v /etc/services-config/%p/mysql:/etc/services-config/mysql \
       busybox:latest \

--- a/run.conf
+++ b/run.conf
@@ -8,7 +8,15 @@ SERVICE_UNIT_LOCAL_ID=1
 SERVICE_UNIT_INSTANCE=1
 
 MOUNT_PATH_CONFIG=/etc/services-config
+# Mac hosts need to be in User writable directory
+if [ "$(uname)" == "Darwin" ]; then
+	MOUNT_PATH_CONFIG=~/services-config
+fi
+
 MOUNT_PATH_DATA=/var/services-data
+if [ "$(uname)" == "Darwin" ]; then
+	MOUNT_PATH_DATA=~/services-data
+fi
 
 MYSQL_DATA_DIR=/var/lib/mysql
 
@@ -21,7 +29,13 @@ VOLUME_CONFIG_NAME=volume-config.${DOCKER_NAME}
 
 get_docker_host_bridge_ip_addr ()
 {
-	echo $(ip addr show ${1:-docker0} | grep -oE "[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}/[0-9]{1,2}")
+	if [ "$(uname)" != "Darwin" ]; then
+		IP=$(ip addr show ${1:-docker0} | grep -oE "[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}/[0-9]{1,2}")
+	else
+		IP=
+	fi
+
+	echo ${IP}
 }
 
 get_docker_host_bridge_ip ()
@@ -68,9 +82,13 @@ get_docker_host_mysql_subnet ()
 		#echo ${IP_OCTETS[0]}.${IP_OCTETS[1]}.${IP_OCTETS[2]}.%
 		;;
 	*)
-		# Exact Match IP - 10.10.10.0
-		echo ${IP}/255.255.255.255
-		#echo ${IP}
+		if [ "${IP}" == "" ] || [ "${IP}" == "0.0.0.0" ]; then
+			# Could not determin IP address or CIDR
+			echo 0.0.0.0/0.0.0.0
+		else
+			# Exact match on IP address only
+			echo ${IP}/255.255.255.255
+		fi
 		;;
 	esac
 }

--- a/run.sh
+++ b/run.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-DIR_PATH="$( cd "$( echo "${0%/*}" )"; pwd )"
-if [[ $DIR_PATH == */* ]]; then
+DIR_PATH="$( if [ "$( echo "${0%/*}" )" != "$( echo "${0}" )" ] ; then cd "$( echo "${0%/*}" )"; fi; pwd )"
+if [[ $DIR_PATH == */* ]] && [[ $DIR_PATH != "$( pwd )" ]] ; then
 	cd $DIR_PATH
 fi
 

--- a/run.sh
+++ b/run.sh
@@ -11,7 +11,7 @@ have_docker_container_name ()
 {
 	NAME=$1
 
-	if [[ -n $(docker ps -a | grep -v -e "${NAME}/.*,.*" | grep -o ${NAME}) ]]; then
+	if [[ -n $(docker ps -a | awk -v pattern="^${NAME}$" '$NF ~ pattern { print $NF; }') ]]; then
 		return 0
 	else
 		return 1
@@ -22,7 +22,7 @@ is_docker_container_name_running ()
 {
 	NAME=$1
 
-	if [[ -n $(docker ps | grep -v -e "${NAME}/.*,.*" | grep -o ${NAME}) ]]; then
+	if [[ -n $(docker ps | awk -v pattern="^${NAME}$" '$NF ~ pattern { print $NF; }') ]]; then
 		return 0
 	else
 		return 1
@@ -112,6 +112,6 @@ docker run \
 fi
 
 if is_docker_container_name_running ${DOCKER_NAME} ; then
-	docker ps | grep -v -e "${DOCKER_NAME}/.*,.*" | grep ${DOCKER_NAME}
+	docker ps | awk -v pattern="${DOCKER_NAME}$" '$NF ~ pattern { print $0 ; }'
 	echo " ---> Docker container running."
 fi

--- a/run.sh
+++ b/run.sh
@@ -44,29 +44,54 @@ remove_docker_container_name ()
 }
 
 # Configuration volume
-if [ ! "${VOLUME_CONFIG_NAME}" == "$(docker ps -a | grep -v -e \"${VOLUME_CONFIG_NAME}/.*,.*\" | grep -e '[ ]\{1,\}'${VOLUME_CONFIG_NAME} | grep -o ${VOLUME_CONFIG_NAME})" ]; then
-	if [ SSH_SERVICE_ENABLED == "true" ]; then
-(
-set -x
-	docker run \
-		--name ${VOLUME_CONFIG_NAME} \
-		-v ${MOUNT_PATH_CONFIG}/ssh.${SERVICE_UNIT_SHARED_GROUP}:/etc/services-config/ssh \
-		-v ${MOUNT_PATH_CONFIG}/${DOCKER_NAME}/supervisor:/etc/services-config/supervisor \
-		-v ${MOUNT_PATH_CONFIG}/${DOCKER_NAME}/mysql:/etc/services-config/mysql \
-		busybox:latest \
-		/bin/true;
-)
-	else
-(
-set -x
-	docker run \
-		--name ${VOLUME_CONFIG_NAME} \
-		-v ${MOUNT_PATH_CONFIG}/${DOCKER_NAME}/supervisor:/etc/services-config/supervisor \
-		-v ${MOUNT_PATH_CONFIG}/${DOCKER_NAME}/mysql:/etc/services-config/mysql \
-		busybox:latest \
-		/bin/true;
-)
+if ! have_docker_container_name ${VOLUME_CONFIG_NAME} ; then
+	# For configuration that is specific to the running container
+	CONTAINER_MOUNT_PATH_CONFIG=${MOUNT_PATH_CONFIG}/${DOCKER_NAME}
+
+	# For configuration that is shared across a group of containers
+	CONTAINER_MOUNT_PATH_CONFIG_SHARED_SSH=${MOUNT_PATH_CONFIG}/ssh.${SERVICE_UNIT_SHARED_GROUP}
+
+	if [ ! -d ${CONTAINER_MOUNT_PATH_CONFIG_SHARED_SSH}/ssh ]; then
+			CMD=$(mkdir -p ${CONTAINER_MOUNT_PATH_CONFIG_SHARED_SSH}/ssh)
+			$CMD || sudo $CMD
 	fi
+
+	# Configuration for SSH is from jdeathe/centos-ssh/etc/services-config/ssh
+	#if [[ ! -n $(find ${CONTAINER_MOUNT_PATH_CONFIG_SHARED_SSH}/ssh -maxdepth 1 -type f) ]]; then
+	#		CMD=$(cp -R etc/services-config/ssh/ ${CONTAINER_MOUNT_PATH_CONFIG_SHARED_SSH}/ssh/)
+	#		$CMD || sudo $CMD
+	#fi
+
+	if [ ! -d ${CONTAINER_MOUNT_PATH_CONFIG}/supervisor ]; then
+			CMD=$(mkdir -p ${CONTAINER_MOUNT_PATH_CONFIG}/supervisor)
+			$CMD || sudo $CMD
+	fi
+
+	if [[ ! -n $(find ${CONTAINER_MOUNT_PATH_CONFIG}/supervisor -maxdepth 1 -type f) ]]; then
+			CMD=$(cp -R etc/services-config/supervisor ${CONTAINER_MOUNT_PATH_CONFIG}/)
+			$CMD || sudo $CMD
+	fi
+
+	if [ ! -d ${CONTAINER_MOUNT_PATH_CONFIG}/mysql ]; then
+			CMD=$(mkdir -p ${CONTAINER_MOUNT_PATH_CONFIG}/mysql)
+			$CMD || sudo $CMD
+	fi
+
+	if [[ ! -n $(find ${CONTAINER_MOUNT_PATH_CONFIG}/mysql -maxdepth 1 -type f) ]]; then
+			CMD=$(cp -R etc/services-config/mysql ${CONTAINER_MOUNT_PATH_CONFIG}/)
+			$CMD || sudo $CMD
+	fi
+
+(
+set -x
+	docker run \
+		--name ${VOLUME_CONFIG_NAME} \
+		-v ${CONTAINER_MOUNT_PATH_CONFIG_SHARED_SSH}/ssh:/etc/services-config/ssh \
+		-v ${CONTAINER_MOUNT_PATH_CONFIG}/supervisor:/etc/services-config/supervisor \
+		-v ${CONTAINER_MOUNT_PATH_CONFIG}/mysql:/etc/services-config/mysql \
+		busybox:latest \
+		/bin/true;
+)
 fi
 
 # Force replace container of same name if found to exist
@@ -83,33 +108,24 @@ else
 	DOCKER_COMMAND=${@}
 fi
 
-# In a sub-shell set xtrace - prints the docker command to screen for reference
 if [ SSH_SERVICE_ENABLED == "true" ]; then
-(
-set -x
-docker run \
-	${DOCKER_OPERATOR_OPTIONS} \
-	--name ${DOCKER_NAME} \
-	-p 3306:3306 \
-	-p 2400:22 \
-	--env MYSQL_SUBNET=${MYSQL_SUBNET:-%} \
-	--volumes-from ${VOLUME_CONFIG_NAME} \
-	-v ${MOUNT_PATH_DATA}/${SERVICE_UNIT_NAME}/${SERVICE_UNIT_SHARED_GROUP}:/var/lib/mysql \
-	${DOCKER_IMAGE_REPOSITORY_NAME} -c "${DOCKER_COMMAND}"
-)
+	DOCKER_PORT_OPTIONS="-p 3306:3306 -p 2400:22"
 else
+	DOCKER_PORT_OPTIONS="-p 3306:3306"
+fi
+
+# In a sub-shell set xtrace - prints the docker command to screen for reference
 (
 set -x
 docker run \
 	${DOCKER_OPERATOR_OPTIONS} \
 	--name ${DOCKER_NAME} \
-	-p 3306:3306 \
+	${DOCKER_PORT_OPTIONS} \
 	--env MYSQL_SUBNET=${MYSQL_SUBNET:-%} \
 	--volumes-from ${VOLUME_CONFIG_NAME} \
 	-v ${MOUNT_PATH_DATA}/${SERVICE_UNIT_NAME}/${SERVICE_UNIT_SHARED_GROUP}:/var/lib/mysql \
 	${DOCKER_IMAGE_REPOSITORY_NAME} -c "${DOCKER_COMMAND}"
 )
-fi
 
 if is_docker_container_name_running ${DOCKER_NAME} ; then
 	docker ps | awk -v pattern="${DOCKER_NAME}$" '$NF ~ pattern { print $0 ; }'


### PR DESCRIPTION
- Build from a specified tag instead of branch.
- Specify package versions, add versionlock package and lock packages.
- Locate the SSH configuration file in a subdirectory to be more consistent.
- Added support for running and building on Mac Docker hosts (when using boot2docker).
- Added a 2 second delay to the supervisor task to start up MySQL so it will give the mysql-bootstrap a chance.
- Made some improvements to the mysql-bootstrap script.
  - Run the initial table installation in the background so the the initialisation SQL can be generated in the foreground.
  - Removed the MySQL shutdown since this should not longer be necessary.
  - Improved the readability by using heredoc syntax for the multiline text instead of lots of echo calls.
  - The permissions on the MySQL data directory are used determine the service users UID/GID this was added for support on Mac hosts with either boot2docker or Kitematic.
  - Moved the socket file out of the MySQL data directory.
- Fixed an issue with deprecated option warnings in the MySQL configuration. 
- Made some improvements to the run.sh helper script.
  - Make the configuration volume the same for both SSH and non-SSH containers.
  - Define the docker run command once and set up the port requirements for SSH if necessary.