### PR TITLE
ISSUE 22: Allow time for custom initilisation SQL to run at startup.

### DIFF
--- a/etc/mysql-bootstrap
+++ b/etc/mysql-bootstrap
@@ -1,13 +1,10 @@
 #!/usr/bin/env bash
 
-# Print commands and their arguments as they are executed.
-#set -x
-
 source /etc/mysql-bootstrap.conf
 
 get_option ()
 {
-	value=$(/usr/bin/my_print_defaults "${1}" | sed -n "s/^--${2}=//p" | tail -n 1)
+	local value=$(/usr/bin/my_print_defaults "${1}" | sed -n "s/^--${2}=//p" | tail -n 1)
 	echo ${value:-$3}
 }
 
@@ -79,6 +76,12 @@ if [[ ! -f ${OPTS_MYSQL_DATA_DIR}/ibdata1 ]]; then
 		Initialisation SQL:
 		$(cat /tmp/mysql-init)
 	EOT
+
+	# Initilisation SQL should be free from blank and comment lines.
+	sed -i \
+		-e 's/-- .*$//' \
+		-e '/^$/d' \
+		/tmp/mysql-init
 
 	# Wait for the MySQL system table installation to complete
 	wait ${!}

--- a/etc/services-config/supervisor/supervisord.conf
+++ b/etc/services-config/supervisor/supervisord.conf
@@ -37,7 +37,7 @@ stdout_events_enabled = true
 
 [program:mysqld_safe]
 priority = 100
-command = /bin/bash -c "/bin/sleep 2 && /usr/bin/pidproxy /var/run/mysqld/mysqld.pid /usr/bin/mysqld_safe"
+command = /bin/bash -c "/bin/sleep 4 && /usr/bin/pidproxy /var/run/mysqld/mysqld.pid /usr/bin/mysqld_safe"
 redirect_stderr = true
 stdout_logfile = /var/log/mysqld.log
 stdout_events_enabled = true


### PR DESCRIPTION
Resolves: https://github.com/jdeathe/centos-ssh-mysql/issues/22