### PR TITLE
ISSUE 28: Updated upstream image to centos-6-1.3.1 tag.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 #		--format '{{ .State.Pid }}' mysql.pool-1.1.1) /bin/bash
 #
 # =============================================================================
-FROM jdeathe/centos-ssh:centos-6-1.3.0
+FROM jdeathe/centos-ssh:centos-6-1.3.1
 
 MAINTAINER James Deathe <james.deathe@gmail.com>
 


### PR DESCRIPTION
Resolves: https://github.com/jdeathe/centos-ssh-mysql/issues/28