### PR TITLE
ISSUE 18: Updated systemd service definition and install helper script.

### DIFF
--- a/mysql.pool-1.1.1@3306.service
+++ b/mysql.pool-1.1.1@3306.service
@@ -13,10 +13,10 @@
 
 [Unit]
 Description=CentOS-6 / MySQL // pool-1.1.1
-After=etcd.service
+After=etcd2.service
 After=docker.service
 Requires=docker.service
-Requires=etcd.service
+Requires=etcd2.service
 
 [Service]
 Restart=on-failure

--- a/mysql.pool-1.1.1@3306.service
+++ b/mysql.pool-1.1.1@3306.service
@@ -32,7 +32,7 @@ ExecStartPre=/bin/sudo /bin/bash -c \
       /usr/bin/docker pull busybox:latest; \
     fi; \
   fi; \
-  if [ ! \"volume-config.%p\" == \"$(/usr/bin/docker ps -a | /bin/awk -v pattern=\\\"^volume-config.%p$\\\" '$NF ~ pattern \{ print $NF; \}')\" ]; then \
+  if [ ! \"volume-config.%p\" == \"$(/usr/bin/docker ps -a | /bin/awk -v pattern='^volume-config.%p$' '$NF ~ pattern { print $NF; }')\" ]; then \
     /usr/bin/docker run \
       --name volume-config.%p \
       -v /etc/services-config/ssh.pool-1/ssh:/etc/services-config/ssh \
@@ -54,8 +54,8 @@ ExecStartPre=/bin/sudo /bin/bash -c \
 
 # Startup: Remove existing container (and stop if running) so it is re-created on startup but not removed on exit - to allow debugging if required
 ExecStart=/bin/sudo /bin/bash -c \
-  "if [ \"%p\" == \"$(/usr/bin/docker ps -a | /bin/awk -v pattern=\\\"^%p$\\\" '$NF ~ pattern \{ print $NF; \}')\" ]; then \
-    if [ \"%p\" == \"$(/usr/bin/docker ps | /bin/awk -v pattern=\\\"^%p$\\\" '$NF ~ pattern \{ print $NF; \}')\" ]; then \
+  "if [ \"%p\" == \"$(/usr/bin/docker ps -a | /bin/awk -v pattern='^%p$' '$NF ~ pattern { print $NF; }')\" ]; then \
+    if [ \"%p\" == \"$(/usr/bin/docker ps | /bin/awk -v pattern='^%p$' '$NF ~ pattern { print $NF; }')\" ]; then \
       /usr/bin/docker stop %p; \
     fi; \
     /usr/bin/docker rm %p; \

--- a/mysql.pool-1.1.1@3306.service
+++ b/mysql.pool-1.1.1@3306.service
@@ -21,7 +21,7 @@ Requires=etcd.service
 [Service]
 Restart=on-failure
 RestartSec=30
-TimeoutStartSec=60
+TimeoutStartSec=1200
 
 # Create a data container for the configuration volume
 ExecStartPre=/bin/sudo /bin/bash -c \
@@ -32,7 +32,7 @@ ExecStartPre=/bin/sudo /bin/bash -c \
       /usr/bin/docker pull busybox:latest; \
     fi; \
   fi; \
-  if [ ! \"volume-config.%p\" == \"$(/usr/bin/docker ps -a | /bin/grep -v -e \\\"volume-config.%p/.*,.*\\\" | /bin/grep -e '[ ]\{1,\}'volume-config.%p | /bin/grep -o volume-config.%p)\" ]; then \
+  if [ ! \"volume-config.%p\" == \"$(/usr/bin/docker ps -a | /bin/awk -v pattern=\\\"^volume-config.%p$\\\" '$NF ~ pattern \{ print $NF; \}')\" ]; then \
     /usr/bin/docker run \
       --name volume-config.%p \
       -v /etc/services-config/ssh.pool-1/ssh:/etc/services-config/ssh \
@@ -54,8 +54,8 @@ ExecStartPre=/bin/sudo /bin/bash -c \
 
 # Startup: Remove existing container (and stop if running) so it is re-created on startup but not removed on exit - to allow debugging if required
 ExecStart=/bin/sudo /bin/bash -c \
-  "if [ \"%p\" == \"$(/usr/bin/docker ps -a | /bin/grep -v -e \\\"%p/.*,.*\\\" | /bin/grep -e '[ ]\{1,\}'%p | /bin/grep -o %p)\" ]; then \
-    if [ \"%p\" == \"$(/usr/bin/docker ps | /bin/grep -v -e \\\"%p/.*,.*\\\" | /bin/grep -e '[ ]\{1,\}'%p | /bin/grep -o %p)\" ]; then \
+  "if [ \"%p\" == \"$(/usr/bin/docker ps -a | /bin/awk -v pattern=\\\"^%p$\\\" '$NF ~ pattern \{ print $NF; \}')\" ]; then \
+    if [ \"%p\" == \"$(/usr/bin/docker ps | /bin/awk -v pattern=\\\"^%p$\\\" '$NF ~ pattern \{ print $NF; \}')\" ]; then \
       /usr/bin/docker stop %p; \
     fi; \
     /usr/bin/docker rm %p; \

--- a/mysql.pool-1.1.1@3306.service
+++ b/mysql.pool-1.1.1@3306.service
@@ -25,14 +25,14 @@ TimeoutStartSec=1200
 
 # Create a data container for the configuration volume
 ExecStartPre=/bin/sudo /bin/bash -c \
-  "if [ ! \"busybox\" == \"$(/usr/bin/docker images | /bin/grep -e '^busybox[ ]\{1,\}' | /bin/grep -o 'busybox')\" ]; then \
-    if [ -f /var/services-packages/busybox.latest-1.0.0.tar.xz ]; then \
+  "if [[ busybox != $(/usr/bin/docker images | /bin/grep -e '^busybox[ ]\{1,\}' | /bin/grep -o 'busybox') ]]; then \
+    if [[ -f /var/services-packages/busybox.latest-1.0.0.tar.xz ]]; then \
       /usr/bin/xz /var/services-packages/busybox.latest-1.0.0.tar.xz | /usr/bin/docker load; \
     else \
       /usr/bin/docker pull busybox:latest; \
     fi; \
   fi; \
-  if [ ! \"volume-config.%p\" == \"$(/usr/bin/docker ps -a | /bin/awk -v pattern='^volume-config.%p$' '$NF ~ pattern { print $NF; }')\" ]; then \
+  if [[ volume-config.%p != $(/usr/bin/docker ps -a | /bin/awk -v pattern='^volume-config.%p$' '$NF ~ pattern { print $NF; }') ]]; then \
     /usr/bin/docker run \
       --name volume-config.%p \
       -v /etc/services-config/ssh.pool-1/ssh:/etc/services-config/ssh \
@@ -44,8 +44,8 @@ ExecStartPre=/bin/sudo /bin/bash -c \
 
 # Initialisation: Pull or build image if required
 ExecStartPre=/bin/sudo /bin/bash -c \
-  "if [ ! \"jdeathe/centos-ssh-mysql\" == \"$(/usr/bin/docker images | /bin/grep -e '^jdeathe/centos-ssh-mysql[ ]\{1,\}' | /bin/grep -o 'jdeathe/centos-ssh-mysql')\" ]; then \
-    if [ -f /var/services-packages/jdeathe/centos-ssh-mysql.centos-6-1.3.0.tar.xz ]; then \
+  "if [[ jdeathe/centos-ssh-mysql != $(/usr/bin/docker images | /bin/grep -e '^jdeathe/centos-ssh-mysql[ ]\{1,\}' | /bin/grep -o 'jdeathe/centos-ssh-mysql') ]]; then \
+    if [[ -f /var/services-packages/jdeathe/centos-ssh-mysql.centos-6-1.3.0.tar.xz ]]; then \
       /usr/bin/xz -dc /var/services-packages/jdeathe/centos-ssh-mysql.centos-6-1.3.0.tar.xz | /usr/bin/docker load; \
     else \
       /usr/bin/docker pull jdeathe/centos-ssh-mysql:centos-6-1.3.0; \
@@ -54,8 +54,8 @@ ExecStartPre=/bin/sudo /bin/bash -c \
 
 # Startup: Remove existing container (and stop if running) so it is re-created on startup but not removed on exit - to allow debugging if required
 ExecStart=/bin/sudo /bin/bash -c \
-  "if [ \"%p\" == \"$(/usr/bin/docker ps -a | /bin/awk -v pattern='^%p$' '$NF ~ pattern { print $NF; }')\" ]; then \
-    if [ \"%p\" == \"$(/usr/bin/docker ps | /bin/awk -v pattern='^%p$' '$NF ~ pattern { print $NF; }')\" ]; then \
+  "if [[ %p == $(/usr/bin/docker ps -a | /bin/awk -v pattern='^%p$' '$NF ~ pattern { print $NF; }') ]]; then \
+    if [[ %p == $(/usr/bin/docker ps | /bin/awk -v pattern='^%p$' '$NF ~ pattern { print $NF; }') ]]; then \
       /usr/bin/docker stop %p; \
     fi; \
     /usr/bin/docker rm %p; \

--- a/mysql.pool-1.1.1@3306.service
+++ b/mysql.pool-1.1.1@3306.service
@@ -2,6 +2,12 @@
 # Create a data container for the configuration volume: 
 #     docker run -v /config --name volume-config.<service-name> busybox /bin/true
 #
+# Optional configuration volume install:
+#     mkdir -p /etc/services-config/<service-name>/{mysql,supervisor}
+#     cp <container-path>/etc/services-config/supervisor/supervisord.conf /etc/services-config/<service-name>/supervisor/supervisord.conf
+#     cp <container-path>/etc/services-config/mysql/my.cnf /etc/services-config/<service-name>/mysql/my.cnf
+#     cp <container-path>/etc/services-config/mysql/mysql-bootstrap.conf /etc/services-config/<service-name>/mysql/mysql-bootstrap.conf 
+#
 # To install: 
 #     sudo cp <container-path>/<service-name>@<port>.service /etc/systemd/system/
 #     sudo systemctl daemon-reload
@@ -32,14 +38,16 @@ ExecStartPre=/bin/sudo /bin/bash -c \
       /usr/bin/docker pull busybox:latest; \
     fi; \
   fi; \
-  if [[ volume-config.%p != $(/usr/bin/docker ps -a | /bin/awk -v pattern='^volume-config.%p$' '$NF ~ pattern { print $NF; }') ]]; then \
-    /usr/bin/docker run \
-      --name volume-config.%p \
-      -v /etc/services-config/ssh.pool-1/ssh:/etc/services-config/ssh \
-      -v /etc/services-config/%p/supervisor:/etc/services-config/supervisor \
-      -v /etc/services-config/%p/mysql:/etc/services-config/mysql \
-      busybox:latest \
-      /bin/true; \
+  if [[ -n $(/usr/bin/find /etc/services-config/%p/supervisor -maxdepth 1 -type f) ]] && [[ -n $(/usr/bin/find /etc/services-config/%p/mysql -maxdepth 1 -type f) ]]; then \
+    if [[ volume-config.%p != $(/usr/bin/docker ps -a | /bin/awk -v pattern='^volume-config.%p$' '$NF ~ pattern { print $NF; }') ]]; then \
+      /usr/bin/docker run \
+        --name volume-config.%p \
+        -v /etc/services-config/ssh.pool-1/ssh:/etc/services-config/ssh \
+        -v /etc/services-config/%p/supervisor:/etc/services-config/supervisor \
+        -v /etc/services-config/%p/mysql:/etc/services-config/mysql \
+        busybox:latest \
+        /bin/true; \
+    fi; \
   fi"
 
 # Initialisation: Pull or build image if required
@@ -60,13 +68,20 @@ ExecStart=/bin/sudo /bin/bash -c \
     fi; \
     /usr/bin/docker rm %p; \
   fi; \
-  /usr/bin/docker run \
-    --privileged \
-    --name %p \
-    -p %i:3306 \
-    --volumes-from volume-config.%p \
-    -v /var/services-data/mysql/pool-1:/var/lib/mysql \
-    jdeathe/centos-ssh-mysql:centos-6-1.3.0"
+  if [[ volume-config.%p == $(/usr/bin/docker ps -a | /bin/awk -v pattern='^volume-config.%p$' '$NF ~ pattern { print $NF; }') ]]; then \
+    /usr/bin/docker run \
+      --name %p \
+      -p %i:3306 \
+      --volumes-from volume-config.%p \
+      -v /var/services-data/mysql/pool-1:/var/lib/mysql \
+      jdeathe/centos-ssh-mysql:centos-6-1.3.0; \
+  else \
+    /usr/bin/docker run \
+      --name %p \
+      -p %i:3306 \
+      -v /var/services-data/mysql/pool-1:/var/lib/mysql \
+      jdeathe/centos-ssh-mysql:centos-6-1.3.0; \
+  fi"
 
 ExecStartPost=/usr/bin/etcdctl set /services/mysql/pool-1/1.1 %H:%i
 

--- a/systemd-install.sh
+++ b/systemd-install.sh
@@ -31,6 +31,6 @@ sudo systemctl enable /etc/systemd/system/${OPT_SERVICE_NAME_FULL}
 echo "WARNING: This may take a while if pulling large container images for the first time..."
 sudo systemctl restart ${OPT_SERVICE_NAME_FULL}
 
-sleep 10
+sleep 30
 
 docker logs ${OPT_SERVICE_NAME_SHORT}

--- a/systemd-install.sh
+++ b/systemd-install.sh
@@ -1,24 +1,35 @@
 #!/usr/bin/env bash
 
-DIR_PATH="$( cd "$( echo "${0%/*}" )"; pwd )"
-if [[ $DIR_PATH == */* ]]; then
+DIR_PATH="$( if [ "$( echo "${0%/*}" )" != "$( echo "${0}" )" ] ; then cd "$( echo "${0%/*}" )"; fi; pwd )"
+if [[ $DIR_PATH == */* ]] && [[ $DIR_PATH != "$( pwd )" ]] ; then
 	cd $DIR_PATH
 fi
 
 OPT_SERVICE_NAME_FULL=${SERVICE_NAME_FULL:-mysql.pool-1.1.1@3306.service}
 OPT_SERVICE_NAME_SHORT=$(cut -d '@' -f1 <<< "${OPT_SERVICE_NAME_FULL}")
 
-# Force 
-systemctl stop ${OPT_SERVICE_NAME_FULL}
-docker rm volume-config.${OPT_SERVICE_NAME_SHORT}
-docker rm ${OPT_SERVICE_NAME_SHORT}
+# Add required configuration directories
+mkdir -p /etc/services-config/${OPT_SERVICE_NAME_SHORT}/{mysql,supervisor}
 
-cp ${OPT_SERVICE_NAME_FULL} /etc/systemd/system/
-systemctl daemon-reload
-systemctl enable /etc/systemd/system/${OPT_SERVICE_NAME_FULL}
+if [[ ! -n $(find /etc/services-config/${OPT_SERVICE_NAME_SHORT}/supervisor -maxdepth 1 -type f) ]]; then
+	cp -R etc/services-config/supervisor /etc/services-config/${OPT_SERVICE_NAME_SHORT}/
+fi
+
+if [[ ! -n $(find /etc/services-config/${OPT_SERVICE_NAME_SHORT}/mysql -maxdepth 1 -type f) ]]; then
+	cp -R etc/services-config/mysql /etc/services-config/${OPT_SERVICE_NAME_SHORT}/
+fi
+
+# Force 
+sudo systemctl stop ${OPT_SERVICE_NAME_FULL}
+docker rm volume-config.${OPT_SERVICE_NAME_SHORT}
+docker stop ${OPT_SERVICE_NAME_SHORT} && docker rm ${OPT_SERVICE_NAME_SHORT}
+
+sudo cp ${OPT_SERVICE_NAME_FULL} /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable /etc/systemd/system/${OPT_SERVICE_NAME_FULL}
 
 echo "WARNING: This may take a while if pulling large container images for the first time..."
-systemctl restart ${OPT_SERVICE_NAME_FULL}
+sudo systemctl restart ${OPT_SERVICE_NAME_FULL}
 
 sleep 10
 


### PR DESCRIPTION
Resolves: https://github.com/jdeathe/centos-ssh-mysql/issues/18

- Implement better docker image name matching.
- Refactored to use bash syntax that requires less quoting to make more readable.
- Updated service definition to make use of etcd2 instead of etcd.
- Increased service timeout to allow longer for the initial docker image pull and container bootstrap initialisation process.
- Added instructions to remind operator's to copy configuration files into place if requiring the configuration volume.
- Added option to exclude the configuration volume.
- Updated installation script to make use of docker helper functions.
- Wait for 30 seconds for the MySQL container bootstrap initialisation process to complete to allow for the log to be fully populated.
- Use sudo for the commands that require it instead of requiring the entire script to need running with sudo (which was undocumented).
