### PR TITLE
CLOSES #82: Enhanced initialisation SQL cleaning.

### DIFF
--- a/etc/services-config/mysql/mysqld-bootstrap.conf
+++ b/etc/services-config/mysql/mysqld-bootstrap.conf
@@ -46,9 +46,14 @@ CUSTOM_MYSQL_INIT_SQL="-- Custom Initialisation SQL can be included in /etc/mysq
 
 if [[ -n ${MYSQL_USER} ]] && [[ -n ${MYSQL_USER_PASSWORD} ]] && [[ -n ${MYSQL_USER_DATABASE} ]]; then
 	read -r -d '' CUSTOM_MYSQL_INIT_SQL <<-EOT
+
 		-- Create database
 		CREATE DATABASE IF NOT EXISTS \`${MYSQL_USER_DATABASE}\`;
+
 		-- Add database access
-		GRANT ALL PRIVILEGES ON \`${MYSQL_USER_DATABASE}\`.* TO '${MYSQL_USER}'@'${MYSQL_USER_HOST}' IDENTIFIED BY '${MYSQL_USER_PASSWORD}';
+		GRANT ALL PRIVILEGES 
+		ON \`${MYSQL_USER_DATABASE}\`.* 
+		TO '${MYSQL_USER}'@'${MYSQL_USER_HOST}' 
+		IDENTIFIED BY '${MYSQL_USER_PASSWORD}';
 	EOT
 fi

--- a/usr/sbin/mysqld-bootstrap
+++ b/usr/sbin/mysqld-bootstrap
@@ -124,7 +124,8 @@ if [[ ! -f ${OPTS_MYSQL_DATA_DIR}/ibdata1 ]]; then
 		/tmp/mysql-init-template \
 		| \
 	sed \
-		-e '/--.*$/d' \
+		-e '/^[ \t]*--.*$/d' \
+		-e 's/;[ \t]*--.*$/;/g' \
 		-e '/^$/d' \
 		| \
 	awk \

--- a/usr/sbin/mysqld-bootstrap
+++ b/usr/sbin/mysqld-bootstrap
@@ -96,7 +96,7 @@ if [[ ! -f ${OPTS_MYSQL_DATA_DIR}/ibdata1 ]]; then
 	PIDS[0]=${!}
 
 	# Generate the initialisation SQL used secure MySQL
-	tee /tmp/mysql-init <<-EOT
+	tee /tmp/mysql-init-template <<-EOT
 
 		-- =============================================================================
 		-- Initialisation SQL
@@ -105,7 +105,9 @@ if [[ ! -f ${OPTS_MYSQL_DATA_DIR}/ibdata1 ]]; then
 		DROP DATABASE IF EXISTS test;
 		DELETE FROM mysql.user WHERE User='' OR User='root' AND Host != 'localhost';
 		DELETE FROM mysql.db WHERE Db='test' OR Db='test\\_%';
-		GRANT ALL PRIVILEGES ON *.* TO 'root'@'localhost' IDENTIFIED BY '${OPTS_MYSQL_ROOT_PASSWORD}' WITH GRANT OPTION;
+		GRANT ALL PRIVILEGES ON *.* TO 'root'@'localhost' 
+		IDENTIFIED BY '${OPTS_MYSQL_ROOT_PASSWORD}' 
+		WITH GRANT OPTION;
 		-- =============================================================================
 		-- Custom Initialisation SQL start
 		-- 
@@ -116,11 +118,18 @@ if [[ ! -f ${OPTS_MYSQL_DATA_DIR}/ibdata1 ]]; then
 		FLUSH PRIVILEGES;
 	EOT
 
-	# Initilisation SQL should be free from blank and comment lines.
-	sed -i \
-		-e 's~--.*$~d' \
-		-e '~^$~d' \
-		/tmp/mysql-init
+	# Each statement must be on a single line and should not include comments.
+	cat \
+		-s \
+		/tmp/mysql-init-template \
+		| \
+	sed \
+		-e '/--.*$/d' \
+		-e '/^$/d' \
+		| \
+	awk \
+		'{ ORS=( /;$/ ? RS:FS ) } 1' \
+		> /tmp/mysql-init
 
 	# Wait for the MySQL system table installation to complete
 	[[ -n ${PIDS[0]} ]] && wait ${PIDS[0]}
@@ -158,7 +167,7 @@ if [[ ! -f ${OPTS_MYSQL_DATA_DIR}/ibdata1 ]]; then
 		-15 \
 		mysqld
 
-	rm -f /tmp/mysql-init
+	rm -f /tmp/mysql-init{,-template}
 
 	TIMER_TOTAL=$(
 		echo - | awk "\

--- a/usr/sbin/mysqld-bootstrap
+++ b/usr/sbin/mysqld-bootstrap
@@ -118,8 +118,8 @@ if [[ ! -f ${OPTS_MYSQL_DATA_DIR}/ibdata1 ]]; then
 
 	# Initilisation SQL should be free from blank and comment lines.
 	sed -i \
-		-e 's/-- .*$//' \
-		-e '/^$/d' \
+		-e 's~--.*$~d' \
+		-e '~^$~d' \
 		/tmp/mysql-init
 
 	# Wait for the MySQL system table installation to complete


### PR DESCRIPTION
- Initialisation SQL must be on a single line and should not include comments.
- Handle SQL that includes invalid comments '--' instead of '-- '.
- Handle SQL that includes trailing comments. e.g. `CREATE DATABASE database; -- Create a database`
- Handle multiline initialisation SQL.
