### PR TITLE
CLOSES #81 Fixed issue detecting completion of MySQL initialisation.

### DIFF
--- a/etc/services-config/mysql/mysqld-bootstrap.conf
+++ b/etc/services-config/mysql/mysqld-bootstrap.conf
@@ -1,22 +1,22 @@
 #!/usr/bin/env bash
 
 # Used by the bootstrap script to determin if MySQL has been initialised. 
-# This value is used if there is no datadir found in the default configuration files.
+# This value is used if there is no datadir found in the default configuration 
+# files.
 MYSQL_DATA_DIR_DEFAULT=/var/lib/mysql
 
-#!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-# WARNING: Will destroy data.
-# Set to 1 to force initialisation of MySQL tables
-# for a clean install and a new auto-generated root password
+# !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+# WARNING: Will destroy all existing data.
+# Set 1 to delete MySQL data directory and re-install on start.
 FORCE_MYSQL_INSTALL=0
-#!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+# !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-# A password is automatically generated on initialisation of the MySQL databases.
-# Check the error-log for the value (i.e docker logs). This default behavior can
-# be overriden and a password specified here.
+# A password is automatically generated during MySQL initialisation.
+# Check the error-log for the value (i.e docker logs). This is the recommended 
+# approach however, you can specify a password with MYSQL_ROOT_PASSWORD.
 MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD:-}
 
-# Set the time to wait for the MySQL initialisation process.
+# Set the time to wait for the MySQL initialisation process before exiting.
 MYSQL_INIT_LIMIT=${MYSQL_INIT_LIMIT:-30}
 
 # -----------------------------------------------------------------------------
@@ -24,7 +24,8 @@ MYSQL_INIT_LIMIT=${MYSQL_INIT_LIMIT:-30}
 # -----------------------------------------------------------------------------
 MYSQL_SUBNET=${MYSQL_SUBNET:-127.0.0.1}
 
-if [[ ${MYSQL_SUBNET} == "0.0.0.0/0.0.0.0" ]] || [[ ${MYSQL_SUBNET} == "0.0.0.0" ]]; then
+if [[ ${MYSQL_SUBNET} == "0.0.0.0/0.0.0.0" ]] \
+	|| [[ ${MYSQL_SUBNET} == "0.0.0.0" ]]; then
 	# Connect from any network
 	MYSQL_USER_HOST=%
 elif [[ ${MYSQL_SUBNET} == "127.0.0.1" ]]; then
@@ -42,9 +43,13 @@ MYSQL_USER_PASSWORD=${MYSQL_USER_PASSWORD:-$(head -n 4096 /dev/urandom | tr -cd 
 # -----------------------------------------------------------------------------
 # Custom SQL run once during initialisation of the database tables
 # -----------------------------------------------------------------------------
-CUSTOM_MYSQL_INIT_SQL="-- Custom Initialisation SQL can be included in /etc/mysql-bootstrap.conf"
+printf \
+	-v CUSTOM_MYSQL_INIT_SQL \
+	-- "-- Custom Initialisation SQL can be included in %s" \
+	'/etc/mysql-bootstrap.conf'
 
-if [[ -n ${MYSQL_USER} ]] && [[ -n ${MYSQL_USER_PASSWORD} ]] && [[ -n ${MYSQL_USER_DATABASE} ]]; then
+if [[ -n ${MYSQL_USER} ]] && [[ -n ${MYSQL_USER_PASSWORD} ]] \
+	&& [[ -n ${MYSQL_USER_DATABASE} ]]; then
 	read -r -d '' CUSTOM_MYSQL_INIT_SQL <<-EOT
 
 		-- Create database

--- a/usr/sbin/mysqld-bootstrap
+++ b/usr/sbin/mysqld-bootstrap
@@ -58,7 +58,7 @@ OPTS_CUSTOM_MYSQL_INIT_SQL=${CUSTOM_MYSQL_INIT_SQL:-}
 OPTS_MYSQL_INIT_LIMIT=${MYSQL_INIT_LIMIT:-30}
 
 if [[ ${OPTS_FORCE_MYSQL_INSTALL} == 1 ]]; then
-	echo "MySQL Database Installation: Purging data directory..."
+	echo "Purging MySQL data directory."
 	rm -rf ${OPTS_MYSQL_DATA_DIR}/*
 fi
 
@@ -135,7 +135,7 @@ if [[ ! -f ${OPTS_MYSQL_DATA_DIR}/ibdata1 ]]; then
 	# Wait for the MySQL system table installation to complete
 	[[ -n ${PIDS[0]} ]] && wait ${PIDS[0]}
 
-	echo "Initialising MySQL..."
+	echo "Initialising MySQL."
 	mysqld_safe \
 		--skip-networking \
 		--init-file=/tmp/mysql-init \
@@ -160,7 +160,7 @@ if [[ ! -f ${OPTS_MYSQL_DATA_DIR}/ibdata1 ]]; then
 		exit 1
 	fi
 
-	echo "Stopping MySQL..."
+	echo "Stopping MySQL."
 	killall \
 		-w \
 		-15 \

--- a/usr/sbin/mysqld-bootstrap
+++ b/usr/sbin/mysqld-bootstrap
@@ -158,7 +158,9 @@ if [[ ! -f ${OPTS_MYSQL_DATA_DIR}/ibdata1 ]]; then
 	done
 
 	if [[ ${COUNTER} -eq 0 ]]; then
-		printf -- "MySQL initilisation failed after %s seconds." "${OPTS_MYSQL_INIT_LIMIT}"
+		printf \
+			-- "MySQL initilisation failed after %s seconds.\n" \
+			"${OPTS_MYSQL_INIT_LIMIT}"
 		exit 1
 	fi
 

--- a/usr/sbin/mysqld-bootstrap
+++ b/usr/sbin/mysqld-bootstrap
@@ -49,37 +49,77 @@ have_mysql_access ()
 	return 1
 }
 
-OPTS_MYSQL_DATA_DIR=$(get_option mysqld datadir "${MYSQL_DATA_DIR_DEFAULT:-/var/lib/mysql}")
-OPTS_MYSQL_SOCKET=$(get_option mysqld socket "/var/run/mysqld/mysql.sock")
+OPTS_MYSQL_DATA_DIR=$(
+	get_option \
+		mysqld \
+		datadir \
+		"${MYSQL_DATA_DIR_DEFAULT:-/var/lib/mysql}"
+)
+OPTS_MYSQL_SOCKET=$(
+	get_option \
+		mysqld \
+		socket \
+		"/var/run/mysqld/mysql.sock"
+)
 OPTS_MYSQL_SOCKET_DIR=${OPTS_MYSQL_SOCKET%/*}
-OPTS_MYSQL_SERVICE_USER=$(get_option mysqld user "mysql")
+OPTS_MYSQL_SERVICE_USER=$(
+	get_option \
+		mysqld \
+		user \
+		"mysql"
+)
 OPTS_FORCE_MYSQL_INSTALL=${FORCE_MYSQL_INSTALL:-0}
 OPTS_CUSTOM_MYSQL_INIT_SQL=${CUSTOM_MYSQL_INIT_SQL:-}
 OPTS_MYSQL_INIT_LIMIT=${MYSQL_INIT_LIMIT:-30}
 
 if [[ ${OPTS_FORCE_MYSQL_INSTALL} == 1 ]]; then
 	echo "Purging MySQL data directory."
-	rm -rf ${OPTS_MYSQL_DATA_DIR}/*
+	rm \
+		-rf \
+		${OPTS_MYSQL_DATA_DIR}/*
 fi
 
 if [[ ! -f ${OPTS_MYSQL_DATA_DIR}/ibdata1 ]]; then
 
-	# Adjust the UID/GID values of the service user to match a directory that could be a mounted volume
+	# Adjust the UID/GID values of the service user to match a directory that 
+	# could be a mounted volume
 	if [[ -d ${OPTS_MYSQL_DATA_DIR} ]]; then
-		SERVICE_UID=$(stat -c "%u" ${OPTS_MYSQL_DATA_DIR})
-		SERVICE_GID=$(stat -c "%g" ${OPTS_MYSQL_DATA_DIR})
+		SERVICE_UID=$(
+			stat \
+				-c \
+				"%u" \
+				${OPTS_MYSQL_DATA_DIR}
+		)
+		SERVICE_GID=$(
+			stat \
+				-c \
+				"%g" \
+				${OPTS_MYSQL_DATA_DIR}
+		)
 
 		if [[ -n ${SERVICE_UID} ]] && [[ ${SERVICE_UID} -ne 0 ]]; then
-			usermod -u ${SERVICE_UID} ${OPTS_MYSQL_SERVICE_USER}
-			chown -R ${OPTS_MYSQL_SERVICE_USER} ${OPTS_MYSQL_SOCKET_DIR:-/var/run/mysqld}
+			usermod \
+				-u \
+				${SERVICE_UID} \
+				${OPTS_MYSQL_SERVICE_USER}
+			chown \
+				-R \
+				${OPTS_MYSQL_SERVICE_USER} \
+				${OPTS_MYSQL_SOCKET_DIR:-/var/run/mysqld}
 		fi
 
 		if [[ -n ${SERVICE_GID} ]] && [[ ${SERVICE_GID} -ne 0 ]]; then
-			groupmod -g ${SERVICE_GID} ${OPTS_MYSQL_SERVICE_USER}
+			groupmod \
+				-g \
+				${SERVICE_GID} \
+				${OPTS_MYSQL_SERVICE_USER}
 
 			# If the group already exists add it to the user's supplementary groups
 			if [[ ${?} -ne 0 ]]; then
-				usermod -G ${SERVICE_GID} ${OPTS_MYSQL_SERVICE_USER}
+				usermod \
+					-G \
+					${SERVICE_GID} \
+					${OPTS_MYSQL_SERVICE_USER}
 			fi
 		fi
 	fi
@@ -166,7 +206,8 @@ if [[ ! -f ${OPTS_MYSQL_DATA_DIR}/ibdata1 ]]; then
 		-15 \
 		mysqld
 
-	rm -f /tmp/mysql-init{,-template}
+	rm -f \
+		/tmp/mysql-init{,-template}
 
 	TIMER_TOTAL=$(
 		echo - | awk "\

--- a/usr/sbin/mysqld-bootstrap
+++ b/usr/sbin/mysqld-bootstrap
@@ -197,17 +197,23 @@ if [[ ! -f ${OPTS_MYSQL_DATA_DIR}/ibdata1 ]]; then
 		printf \
 			-- "MySQL initilisation failed after %s seconds.\n" \
 			"${OPTS_MYSQL_INIT_LIMIT}"
+
+		killall \
+			-15 \
+			mysqld
+
 		exit 1
+	else
+		echo "Stopping MySQL."
+
+		mysqladmin \
+			--user=root \
+			--password=${OPTS_MYSQL_ROOT_PASSWORD} \
+			shutdown
+
+		rm -f \
+			/tmp/mysql-init{,-template}
 	fi
-
-	echo "Stopping MySQL."
-	killall \
-		-w \
-		-15 \
-		mysqld
-
-	rm -f \
-		/tmp/mysql-init{,-template}
 
 	TIMER_TOTAL=$(
 		echo - | awk "\

--- a/usr/sbin/mysqld-bootstrap
+++ b/usr/sbin/mysqld-bootstrap
@@ -147,11 +147,7 @@ if [[ ! -f ${OPTS_MYSQL_DATA_DIR}/ibdata1 ]]; then
 		sleep 0.5
 
 		if have_mysql_access root ${OPTS_MYSQL_ROOT_PASSWORD} mysql; then
-			if [[ -z ${MYSQL_USER} ]] || [[ -z ${MYSQL_USER_DATABASE} ]] || [[ -z ${MYSQL_USER_PASSWORD} ]] ; then
-				break
-			elif have_mysql_access ${MYSQL_USER} ${MYSQL_USER_PASSWORD} ${MYSQL_USER_DATABASE}; then
-				break
-			fi
+			break
 		fi
 
 		(( COUNTER -= 1 ))

--- a/usr/sbin/mysqld-bootstrap
+++ b/usr/sbin/mysqld-bootstrap
@@ -105,9 +105,6 @@ if [[ ! -f ${OPTS_MYSQL_DATA_DIR}/ibdata1 ]]; then
 		DROP DATABASE IF EXISTS test;
 		DELETE FROM mysql.user WHERE User='' OR User='root' AND Host != 'localhost';
 		DELETE FROM mysql.db WHERE Db='test' OR Db='test\\_%';
-		GRANT ALL PRIVILEGES ON *.* TO 'root'@'localhost' 
-		IDENTIFIED BY '${OPTS_MYSQL_ROOT_PASSWORD}' 
-		WITH GRANT OPTION;
 		-- =============================================================================
 		-- Custom Initialisation SQL start
 		-- 
@@ -115,6 +112,9 @@ if [[ ! -f ${OPTS_MYSQL_DATA_DIR}/ibdata1 ]]; then
 		-- 
 		-- Custom Initialisation SQL end
 		-- -----------------------------------------------------------------------------
+		GRANT ALL PRIVILEGES ON *.* TO 'root'@'localhost' 
+		IDENTIFIED BY '${OPTS_MYSQL_ROOT_PASSWORD}' 
+		WITH GRANT OPTION;
 		FLUSH PRIVILEGES;
 	EOT
 


### PR DESCRIPTION
- Simplified MySQL access test - only local root access test is necessary to confirm completion.
- Made some syntax changes for readability.
- Kill mysqld on initialisation error.
