### PR TITLE
CLOSES #80: Updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The Dockerfile can be used to build a base image that is the bases for several o
 
 Included in the build are the [EPEL](http://fedoraproject.org/wiki/EPEL) and [IUS](https://ius.io/) repositories. Installed packages include [OpenSSH](http://www.openssh.com/portable.html) secure shell, [vim-minimal](http://www.vim.org/), [MySQL Server and client programs](http://www.mysql.com) are installed along with python-setuptools, [supervisor](http://supervisord.org/) and [supervisor-stdout](https://github.com/coderanger/supervisor-stdout).
 
-Supervisor is used to start the mysqld server daemon when a docker container based on this image is run. To enable simple viewing of stdout for the service's subprocess, supervisor-stdout is included. This allows you to see output from the supervisord controlled subprocesses with ```docker logs {container-name}```.
+Supervisor is used to start the mysqld server daemon when a docker container based on this image is run. To enable simple viewing of stdout for the service's subprocess, supervisor-stdout is included. This allows you to see output from the supervisord controlled subprocesses with `docker logs {container-name}`.
 
 If enabling and configuring SSH access, it is by public key authentication and, by default, the [Vagrant](http://www.vagrantup.com/) [insecure private key](https://github.com/mitchellh/vagrant/blob/master/keys/vagrant) is required.
 
@@ -31,7 +31,7 @@ For cases where access to docker exec is not possible the preferred method is to
 
 ## Quick Example
 
-Run up a container named ```mysql.pool-1.1.1``` from the docker image ```jdeathe/centos-ssh-mysql``` on port 3306 of your docker host.
+Run up a container named `mysql.pool-1.1.1` from the docker image `jdeathe/centos-ssh-mysql` on port 3306 of your docker host.
 
 ```
 $ docker run -d \
@@ -51,7 +51,7 @@ If it is the first run there should be additional output showing the initialisat
 
 ![Docker Logs MySQL Bootstrap](https://raw.github.com/jdeathe/centos-ssh-mysql/centos-6/images/docker-logs-mysql-bootstrap.png)
 
-The MySQL table data is persistent across container restarts by setting the MySQL data directory ```/var/lib/mysql``` as a data volume. We didn't specify a name or docker_host path so Docker will give it a unique name and store it in ```/var/lib/docker/volumes/```; to find out where the data is stored on the Docker host you can use ```docker inspect```.
+The MySQL table data is persistent across container restarts by setting the MySQL data directory `/var/lib/mysql` as a data volume. We didn't specify a name or docker_host path so Docker will give it a unique name and store it in `/var/lib/docker/volumes/`; to find out where the data is stored on the Docker host you can use `docker inspect`.
 
 ```
 $ docker inspect \
@@ -125,7 +125,7 @@ $ docker run \
   /bin/true
 ```
 
-To identify the docker host directory path to the volume within the container `volume-config.mysql.pool-1.1.1` you can use ```docker inspect``` to view the Mounts.
+To identify the docker host directory path to the volume within the container `volume-config.mysql.pool-1.1.1` you can use `docker inspect` to view the Mounts.
 
 ```
 $ docker inspect \
@@ -146,7 +146,7 @@ $ docker run \
 ```
 
 ##### Populating Named configuration data volumes  
-When using named volumes the directory path from the docker host mounts the path on the container so we need to upload the configuration files. The simplest method of achieving this is to upload the contents of the [etc/services-config](https://github.com/jdeathe/centos-ssh-mysql/blob/centos-6/etc/services-config/) directory using ```docker cp```.
+When using named volumes the directory path from the docker host mounts the path on the container so we need to upload the configuration files. The simplest method of achieving this is to upload the contents of the [etc/services-config](https://github.com/jdeathe/centos-ssh-mysql/blob/centos-6/etc/services-config/) directory using `docker cp`.
 
 ```
 $ docker cp \
@@ -170,7 +170,7 @@ $ docker run -d \
 
 #### Editing configuration
 
-To make changes to the configuration files you need a running container that uses the volumes from the configuration volume. To edit a single file you could use the following, where {path_to_file} can be one of the [required configuration files](https://github.com/jdeathe/centos-ssh-mysql/blob/centos-6/README.md#required-configuration-files), or you could run a ```bash``` shell and then make the changes required using ```vi```. On exiting the container it will be removed since we specify the ```--rm``` parameter.
+To make changes to the configuration files you need a running container that uses the volumes from the configuration volume. To edit a single file you could use the following, where {path_to_file} can be one of the [required configuration files](https://github.com/jdeathe/centos-ssh-mysql/blob/centos-6/README.md#required-configuration-files), or you could run a `bash` shell and then make the changes required using `vi`. On exiting the container it will be removed since we specify the `--rm` parameter.
 
 ```
 $ docker run --rm -it \
@@ -221,7 +221,7 @@ $ docker run -d \
 
 The following example uses the settings from the optional configuration volume volume-config.mysql.pool-1.1.1 and maps a data volume for persistent storage of the MySQL data on the docker host.
 
-*Note:* In the above example we are using ```docker volume rm``` to destroy the named data volume and allow the mysql-bootstrap initialisation process to run. This might be necessary if the named data volume already exists from the previous example but should be **used with caution** since it will **destroy all existing mysql data** for any containers that use it.
+*Note:* In the above example we are using `docker volume rm` to destroy the named data volume and allow the mysql-bootstrap initialisation process to run. This might be necessary if the named data volume already exists from the previous example but should be **used with caution** since it will **destroy all existing mysql data** for any containers that use it.
 
 ```
 $ docker stop mysql.pool-1.1.1 && \
@@ -238,7 +238,7 @@ $ docker run -d \
   jdeathe/centos-ssh-mysql:centos-6
 ```
 
-The environmental variable ```MYSQL_SUBNET``` is optional but can be used to generate users with access to databases outside the ```localhost```, (the default for the root user). In the example, the subnet definition ```0.0.0.0/0.0.0.0``` allows connections from any network which is equivalent to the wildcard symbol, `%`, in MySQL GRANT definitions.
+The environmental variable `MYSQL_SUBNET` is optional but can be used to generate users with access to databases outside the `localhost`, (the default for the root user). In the example, the subnet definition `0.0.0.0/0.0.0.0` allows connections from any network which is equivalent to the wildcard symbol, `%`, in MySQL GRANT definitions.
 
 Now you can verify it is initialised and running successfully by inspecting the container's logs:
 
@@ -254,7 +254,7 @@ There are several environmental variables defined at runtime these allow the ope
 
 ##### MYSQL_ROOT_PASSWORD
 
-On first run the root user is created with an auto-generated password. If you require a specific password,  ```MYSQL_ROOT_PASSWORD``` can be used when running the container.
+On first run the root user is created with an auto-generated password. If you require a specific password,  `MYSQL_ROOT_PASSWORD` can be used when running the container.
 
 ```
 ...
@@ -264,7 +264,7 @@ On first run the root user is created with an auto-generated password. If you re
 
 ##### MYSQL_USER
 
-On first run, a database user and database can be created. Set ```MYSQL_USER``` to a non-empty string. A corresponding ```MYSQL_USER_DATABASE``` value must also be set for the user to be given access too.
+On first run, a database user and database can be created. Set `MYSQL_USER` to a non-empty string. A corresponding `MYSQL_USER_DATABASE` value must also be set for the user to be given access too.
 
 ```
 ...
@@ -274,7 +274,7 @@ On first run, a database user and database can be created. Set ```MYSQL_USER``` 
 
 ##### MYSQL_USER_PASSWORD
 
-On first run, if the database user ```MYSQL_USER``` is specified then it is created with an auto-generated password. If you require a specific password,  ```MYSQL_USER_PASSWORD``` can be used when running the container.
+On first run, if the database user `MYSQL_USER` is specified then it is created with an auto-generated password. If you require a specific password,  `MYSQL_USER_PASSWORD` can be used when running the container.
 
 ```
 ...
@@ -284,7 +284,7 @@ On first run, if the database user ```MYSQL_USER``` is specified then it is crea
 
 ##### MYSQL_USER_DATABASE
 
-On first run, if the database user ```MYSQL_USER``` is specified then you must also define a corresponding database name.  ```MYSQL_USER_DATABASE``` can be used when running the container.
+On first run, if the database user `MYSQL_USER` is specified then you must also define a corresponding database name.  `MYSQL_USER_DATABASE` can be used when running the container.
 
 ```
 ...
@@ -294,11 +294,11 @@ On first run, if the database user ```MYSQL_USER``` is specified then you must a
 
 ### Custom Configuration
 
-If using the optional data volume for container configuration you are able to customise the configuration. In the following examples your custom docker configuration files should be located on the Docker host under the directory ```/var/lib/docker/volumes/{volume-name}/``` where ```{volume-name}``` should identify the applicable container name such as "volume-config.mysql.pool-1.1.1" if using named volumes or will be an ID generated automatically by Docker. To identify the correct path on the Docker host use the ```docker inspect``` command.
+If using the optional data volume for container configuration you are able to customise the configuration. In the following examples your custom docker configuration files should be located on the Docker host under the directory `/var/lib/docker/volumes/{volume-name}/` where `{volume-name}` should identify the applicable container name such as "volume-config.mysql.pool-1.1.1" if using named volumes or will be an ID generated automatically by Docker. To identify the correct path on the Docker host use the `docker inspect` command.
 
 #### [mysql/mysql-bootstrap.conf](https://github.com/jdeathe/centos-ssh-mysql/blob/centos-6/etc/services-config/mysql/mysql-bootstrap.conf)
 
-The bootstrap script initialises the MySQL install with ```/usr/bin/mysql_install_db``` then secures it and applies any custom SQL with ```/usr/bin/mysqld_safe``` - any test or root users and test databases are dropped, then a password for the localhost only MySQL root user is generated.
+The bootstrap script initialises the MySQL install with `/usr/bin/mysql_install_db` then secures it and applies any custom SQL with `/usr/bin/mysqld_safe` - any test or root users and test databases are dropped, then a password for the localhost only MySQL root user is generated.
 
 #### [mysql/my.cnf](https://github.com/jdeathe/centos-ssh-mysql/blob/centos-6/etc/services-config/mysql/my.cnf)
 


### PR DESCRIPTION
- Removed outdated instructions on how to delete data volume. The docker host path `/var/services-data/`is not longer used in the volume examples due to docker deprecating the feature to auto-create host directories and having introduced the `docker volume` command to simplify volume management.
- Changed `MYSQL_SUBNET` examples to use `IP_ADDRESS/SUBNET` type examples.
- Spaced out command examples to help clarity.
- For consistency, use '`' in inline text examples and '```' in code blocks. 
