### PR TITLE
CLOSES #79: Added check if service user UID/GID change is necessary

### DIFF
--- a/usr/sbin/mysqld-bootstrap
+++ b/usr/sbin/mysqld-bootstrap
@@ -96,8 +96,19 @@ if [[ ! -f ${OPTS_MYSQL_DATA_DIR}/ibdata1 ]]; then
 				"%g" \
 				${OPTS_MYSQL_DATA_DIR}
 		)
+		MYSQL_SERVICE_USER_UID=$(
+			id \
+				-u \
+				${OPTS_MYSQL_SERVICE_USER}
+		)
+		MYSQL_SERVICE_USER_GID=$(
+			id \
+				-g \
+				${OPTS_MYSQL_SERVICE_USER}
+		)
 
-		if [[ -n ${SERVICE_UID} ]] && [[ ${SERVICE_UID} -ne 0 ]]; then
+		if [[ -n ${SERVICE_UID} ]] && [[ ${SERVICE_UID} -ne 0 ]] \
+			&& [[ ${SERVICE_UID} != ${MYSQL_SERVICE_USER_UID} ]]; then
 			usermod \
 				-u \
 				${SERVICE_UID} \
@@ -105,22 +116,21 @@ if [[ ! -f ${OPTS_MYSQL_DATA_DIR}/ibdata1 ]]; then
 			chown \
 				-R \
 				${OPTS_MYSQL_SERVICE_USER} \
-				${OPTS_MYSQL_SOCKET_DIR:-/var/run/mysqld}
+				${OPTS_MYSQL_SOCKET_DIR}
 		fi
 
-		if [[ -n ${SERVICE_GID} ]] && [[ ${SERVICE_GID} -ne 0 ]]; then
+		if [[ -n ${SERVICE_GID} ]] && [[ ${SERVICE_GID} -ne 0 ]] \
+			&& [[ ${SERVICE_GID} != ${MYSQL_SERVICE_USER_GID} ]]; then
 			groupmod \
 				-g \
 				${SERVICE_GID} \
 				${OPTS_MYSQL_SERVICE_USER}
-
-			# If the group already exists add it to the user's supplementary groups
-			if [[ ${?} -ne 0 ]]; then
-				usermod \
-					-G \
-					${SERVICE_GID} \
-					${OPTS_MYSQL_SERVICE_USER}
-			fi
+		elif [[ -n ${SERVICE_GID} ]] && [[ ${SERVICE_GID} -ne 0 ]]; then
+			# Add as a supplementary group
+			usermod \
+				-G \
+				${SERVICE_GID} \
+				${OPTS_MYSQL_SERVICE_USER}
 		fi
 	fi
 

--- a/usr/sbin/mysqld-bootstrap
+++ b/usr/sbin/mysqld-bootstrap
@@ -138,11 +138,11 @@ if [[ ! -f ${OPTS_MYSQL_DATA_DIR}/ibdata1 ]]; then
 
 	echo "Initalising MySQL data directory."
 	mysql_install_db \
-		--verbose \
 		--force \
 		--skip-name-resolve \
 		--skip-networking \
-		--tmpdir=${OPTS_MYSQL_DATA_DIR} &
+		--tmpdir=${OPTS_MYSQL_DATA_DIR} \
+		&
 	PIDS[0]=${!}
 
 	# Generate the initialisation SQL used secure MySQL
@@ -192,7 +192,9 @@ if [[ ! -f ${OPTS_MYSQL_DATA_DIR}/ibdata1 ]]; then
 		&
 
 	# Wait for the MySQL database to be initialised by testing 
-	COUNTER=$(( 2 * ${OPTS_MYSQL_INIT_LIMIT} ))
+	COUNTER=$((
+		2 * ${OPTS_MYSQL_INIT_LIMIT} 
+	))
 	while (( ${COUNTER} >= 1 )); do
 		sleep 0.5
 


### PR DESCRIPTION
Resolves #79 
- Fixed issue with "usermod: no changes" showing in the logs. Added check if change is required.
- Removed '--verbose' parameter from `mysql_install_db` as it's unnecessary.
