### PR TITLE
CLOSES #77: Moved MySQL bootstrap logic out of configuration file.

### DIFF
--- a/etc/services-config/mysql/mysqld-bootstrap.conf
+++ b/etc/services-config/mysql/mysqld-bootstrap.conf
@@ -34,18 +34,3 @@ printf \
 	-v CUSTOM_MYSQL_INIT_SQL \
 	-- "-- Custom Initialisation SQL can be included in %s" \
 	'/etc/mysql-bootstrap.conf'
-
-if [[ -n ${MYSQL_USER} ]] && [[ -n ${MYSQL_USER_PASSWORD} ]] \
-	&& [[ -n ${MYSQL_USER_DATABASE} ]]; then
-	read -r -d '' CUSTOM_MYSQL_INIT_SQL <<-EOT
-
-		-- Create database
-		CREATE DATABASE IF NOT EXISTS \`{{MYSQL_USER_DATABASE}}\`;
-
-		-- Add database access
-		GRANT ALL PRIVILEGES 
-		ON \`{{MYSQL_USER_DATABASE}}\`.* 
-		TO '{{MYSQL_USER}}'@'{{MYSQL_USER_HOST}}' 
-		IDENTIFIED BY '{{MYSQL_USER_PASSWORD}}';
-	EOT
-fi

--- a/etc/services-config/mysql/mysqld-bootstrap.conf
+++ b/etc/services-config/mysql/mysqld-bootstrap.conf
@@ -23,22 +23,9 @@ MYSQL_INIT_LIMIT=${MYSQL_INIT_LIMIT:-30}
 # Custom Application specific setup
 # -----------------------------------------------------------------------------
 MYSQL_SUBNET=${MYSQL_SUBNET:-127.0.0.1}
-
-if [[ ${MYSQL_SUBNET} == "0.0.0.0/0.0.0.0" ]] \
-	|| [[ ${MYSQL_SUBNET} == "0.0.0.0" ]]; then
-	# Connect from any network
-	MYSQL_USER_HOST=%
-elif [[ ${MYSQL_SUBNET} == "127.0.0.1" ]]; then
-	# Internal connection
-	MYSQL_USER_HOST=localhost
-else
-	# User defined host / subnet
-	MYSQL_USER_HOST=${MYSQL_SUBNET}
-fi
-
 MYSQL_USER=${MYSQL_USER:-}
 MYSQL_USER_DATABASE=${MYSQL_USER_DATABASE:-}
-MYSQL_USER_PASSWORD=${MYSQL_USER_PASSWORD:-$(head -n 4096 /dev/urandom | tr -cd '[:alnum:]' | cut -c1-8)}
+MYSQL_USER_PASSWORD=${MYSQL_USER_PASSWORD:-}
 
 # -----------------------------------------------------------------------------
 # Custom SQL run once during initialisation of the database tables
@@ -53,12 +40,12 @@ if [[ -n ${MYSQL_USER} ]] && [[ -n ${MYSQL_USER_PASSWORD} ]] \
 	read -r -d '' CUSTOM_MYSQL_INIT_SQL <<-EOT
 
 		-- Create database
-		CREATE DATABASE IF NOT EXISTS \`${MYSQL_USER_DATABASE}\`;
+		CREATE DATABASE IF NOT EXISTS \`{{MYSQL_USER_DATABASE}}\`;
 
 		-- Add database access
 		GRANT ALL PRIVILEGES 
-		ON \`${MYSQL_USER_DATABASE}\`.* 
-		TO '${MYSQL_USER}'@'${MYSQL_USER_HOST}' 
-		IDENTIFIED BY '${MYSQL_USER_PASSWORD}';
+		ON \`{{MYSQL_USER_DATABASE}}\`.* 
+		TO '{{MYSQL_USER}}'@'{{MYSQL_USER_HOST}}' 
+		IDENTIFIED BY '{{MYSQL_USER_PASSWORD}}';
 	EOT
 fi

--- a/usr/sbin/mysqld-bootstrap
+++ b/usr/sbin/mysqld-bootstrap
@@ -351,8 +351,8 @@ if ! is_mysql_data_directory_populated ${OPTS_MYSQL_DATA_DIR}; then
 		================================================================================
 		MySQL Details
 		--------------------------------------------------------------------------------
+		database : ${OPTS_MYSQL_USER_DATABASE:-N/A}
 		${DETAILS_MYSQL_USER_CREDENTIALS}
-		databases : ${OPTS_MYSQL_USER_DATABASE:-N/A}
 		--------------------------------------------------------------------------------
 		${TIMER_TOTAL}
 

--- a/usr/sbin/mysqld-bootstrap
+++ b/usr/sbin/mysqld-bootstrap
@@ -49,12 +49,24 @@ have_mysql_access ()
 	return 1
 }
 
-OPTS_MYSQL_DATA_DIR=$(
+is_mysql_data_directory_populated ()
+{
+	local MYSQL_DATA_DIRECTORY=${1:-/var/lib/mysql}
+
+	# Test for the InnoDB shared tablespace
+	if [[ -f ${MYSQL_DATA_DIRECTORY}/ibdata1 ]]; then
+		return 0
+	fi
+
+	return 1
+}
+
+OPTS_MYSQL_DATA_DIR="$(
 	get_option \
 		mysqld \
 		datadir \
 		"${MYSQL_DATA_DIR_DEFAULT:-/var/lib/mysql}"
-)
+)"
 OPTS_FORCE_MYSQL_INSTALL=${FORCE_MYSQL_INSTALL:-0}
 
 if [[ ${OPTS_FORCE_MYSQL_INSTALL} == 1 ]]; then
@@ -65,7 +77,7 @@ if [[ ${OPTS_FORCE_MYSQL_INSTALL} == 1 ]]; then
 fi
 
 # MySQL initialisation is a one-shot process.
-if [[ ! -f ${OPTS_MYSQL_DATA_DIR}/ibdata1 ]]; then
+if ! is_mysql_data_directory_populated ${OPTS_MYSQL_DATA_DIR}; then
 
 	PASSWORD_LENGTH=8
 

--- a/usr/sbin/mysqld-bootstrap
+++ b/usr/sbin/mysqld-bootstrap
@@ -190,11 +190,8 @@ if ! is_mysql_data_directory_populated ${OPTS_MYSQL_DATA_DIR}; then
 		&
 	PIDS[0]=${!}
 
-	# Generate the initialisation SQL used secure MySQL
-	tee \
-		/tmp/mysql-init-template \
-		<<-EOT
-
+	# Build the SQL required at the start of initialisation
+	read -r -d '' MYSQL_INIT_SQL_HEAD_TEMPLATE <<-EOT
 		-- =============================================================================
 		-- Initialisation SQL
 		-- -----------------------------------------------------------------------------
@@ -202,6 +199,61 @@ if ! is_mysql_data_directory_populated ${OPTS_MYSQL_DATA_DIR}; then
 		DROP DATABASE IF EXISTS test;
 		DELETE FROM mysql.user WHERE User='' OR User='root' AND Host != 'localhost';
 		DELETE FROM mysql.db WHERE Db='test' OR Db='test\\_%';
+	EOT
+
+	# Build the SQL required at the end of initialisation
+	read -r -d '' MYSQL_INIT_SQL_TAIL_TEMPLATE <<-EOT
+		GRANT ALL PRIVILEGES 
+		ON *.* 
+		TO 'root'@'localhost' 
+		IDENTIFIED BY '{{MYSQL_ROOT_PASSWORD}}' 
+		WITH GRANT OPTION;
+		FLUSH PRIVILEGES;
+	EOT
+
+	MYSQL_INIT_SQL_DATABASE_TEMPLATE="-- Create database"
+	if [[ -n ${OPTS_MYSQL_USER_DATABASE} ]]; then
+		printf \
+			-v MYSQL_INIT_SQL_DATABASE_TEMPLATE \
+			-- "%s\nCREATE DATABASE IF NOT EXISTS \`%s\`;" \
+			"${MYSQL_INIT_SQL_DATABASE_TEMPLATE}" \
+			"{{MYSQL_USER_DATABASE}}"
+	fi
+
+	MYSQL_INIT_SQL_USER_TEMPLATE="-- Create user"
+	if [[ -n ${OPTS_MYSQL_USER} ]] \
+		&& [[ -n ${OPTS_MYSQL_USER_HOST} ]]; then
+		printf \
+			-v MYSQL_INIT_SQL_USER_TEMPLATE \
+			-- "%s\nCREATE USER '%s'@'%s' \nIDENTIFIED BY '%s';" \
+			"${MYSQL_INIT_SQL_USER_TEMPLATE}" \
+			"{{MYSQL_USER}}" \
+			"{{MYSQL_USER_HOST}}" \
+			"{{MYSQL_USER_PASSWORD}}"
+	fi
+
+	MYSQL_INIT_SQL_PRIVILEGES_TEMPLATE="-- Grant privileges"
+	if [[ -n ${OPTS_MYSQL_USER} ]] \
+		&& [[ -n ${OPTS_MYSQL_USER_DATABASE} ]] \
+		&& [[ -n ${OPTS_MYSQL_USER_HOST} ]]; then
+		printf \
+			-v MYSQL_INIT_SQL_PRIVILEGES_TEMPLATE \
+			-- "%s\nGRANT %s \nON \`%s\`.* \nTO '%s'@'%s';" \
+			"${MYSQL_INIT_SQL_PRIVILEGES_TEMPLATE}" \
+			"ALL PRIVILEGES" \
+			"{{MYSQL_USER_DATABASE}}" \
+			"{{MYSQL_USER}}" \
+			"{{MYSQL_USER_HOST}}"
+	fi
+
+	# Generate the initialisation SQL used secure MySQL
+	tee \
+		/tmp/mysql-init-template \
+		<<-EOT
+
+		${MYSQL_INIT_SQL_HEAD_TEMPLATE}
+		${MYSQL_INIT_SQL_DATABASE_TEMPLATE}
+		${MYSQL_INIT_SQL_USER_TEMPLATE}
 		-- =============================================================================
 		-- Custom Initialisation SQL start
 		-- 
@@ -209,10 +261,8 @@ if ! is_mysql_data_directory_populated ${OPTS_MYSQL_DATA_DIR}; then
 		-- 
 		-- Custom Initialisation SQL end
 		-- -----------------------------------------------------------------------------
-		GRANT ALL PRIVILEGES ON *.* TO 'root'@'localhost' 
-		IDENTIFIED BY '{{MYSQL_ROOT_PASSWORD}}' 
-		WITH GRANT OPTION;
-		FLUSH PRIVILEGES;
+		${MYSQL_INIT_SQL_PRIVILEGES_TEMPLATE}
+		${MYSQL_INIT_SQL_TAIL_TEMPLATE}
 	EOT
 
 	# Each statement must be on a single line and should not include comments.

--- a/usr/sbin/mysqld-bootstrap
+++ b/usr/sbin/mysqld-bootstrap
@@ -55,22 +55,7 @@ OPTS_MYSQL_DATA_DIR=$(
 		datadir \
 		"${MYSQL_DATA_DIR_DEFAULT:-/var/lib/mysql}"
 )
-OPTS_MYSQL_SOCKET=$(
-	get_option \
-		mysqld \
-		socket \
-		"/var/run/mysqld/mysql.sock"
-)
-OPTS_MYSQL_SOCKET_DIR=${OPTS_MYSQL_SOCKET%/*}
-OPTS_MYSQL_SERVICE_USER=$(
-	get_option \
-		mysqld \
-		user \
-		"mysql"
-)
 OPTS_FORCE_MYSQL_INSTALL=${FORCE_MYSQL_INSTALL:-0}
-OPTS_CUSTOM_MYSQL_INIT_SQL=${CUSTOM_MYSQL_INIT_SQL:-}
-OPTS_MYSQL_INIT_LIMIT=${MYSQL_INIT_LIMIT:-30}
 
 if [[ ${OPTS_FORCE_MYSQL_INSTALL} == 1 ]]; then
 	echo "Purging MySQL data directory."
@@ -79,7 +64,27 @@ if [[ ${OPTS_FORCE_MYSQL_INSTALL} == 1 ]]; then
 		${OPTS_MYSQL_DATA_DIR}/*
 fi
 
+# MySQL initialisation is a one-shot process.
 if [[ ! -f ${OPTS_MYSQL_DATA_DIR}/ibdata1 ]]; then
+
+	PASSWORD_LENGTH=8
+
+	OPTS_CUSTOM_MYSQL_INIT_SQL="${CUSTOM_MYSQL_INIT_SQL:-}"
+	OPTS_MYSQL_INIT_LIMIT="${MYSQL_INIT_LIMIT:-30}"
+	OPTS_MYSQL_ROOT_PASSWORD="${MYSQL_ROOT_PASSWORD:-$(get_password ${PASSWORD_LENGTH})}"
+	OPTS_MYSQL_SERVICE_USER="$(
+		get_option \
+			mysqld \
+			user \
+			"mysql"
+	)"
+	OPTS_MYSQL_SOCKET="$(
+		get_option \
+			mysqld \
+			socket \
+			"/var/run/mysqld/mysql.sock"
+	)"
+	OPTS_MYSQL_SOCKET_DIR="${OPTS_MYSQL_SOCKET%/*}"
 
 	# Adjust the UID/GID values of the service user to match a directory that 
 	# could be a mounted volume
@@ -133,8 +138,6 @@ if [[ ! -f ${OPTS_MYSQL_DATA_DIR}/ibdata1 ]]; then
 				${OPTS_MYSQL_SERVICE_USER}
 		fi
 	fi
-
-	OPTS_MYSQL_ROOT_PASSWORD="${MYSQL_ROOT_PASSWORD:-$(get_password 8)}"
 
 	echo "Initalising MySQL data directory."
 	mysql_install_db \

--- a/usr/sbin/mysqld-bootstrap
+++ b/usr/sbin/mysqld-bootstrap
@@ -190,27 +190,6 @@ if ! is_mysql_data_directory_populated ${OPTS_MYSQL_DATA_DIR}; then
 		&
 	PIDS[0]=${!}
 
-	# Build the SQL required at the start of initialisation
-	read -r -d '' MYSQL_INIT_SQL_HEAD_TEMPLATE <<-EOT
-		-- =============================================================================
-		-- Initialisation SQL
-		-- -----------------------------------------------------------------------------
-		-- Secure MySQL
-		DROP DATABASE IF EXISTS test;
-		DELETE FROM mysql.user WHERE User='' OR User='root' AND Host != 'localhost';
-		DELETE FROM mysql.db WHERE Db='test' OR Db='test\\_%';
-	EOT
-
-	# Build the SQL required at the end of initialisation
-	read -r -d '' MYSQL_INIT_SQL_TAIL_TEMPLATE <<-EOT
-		GRANT ALL PRIVILEGES 
-		ON *.* 
-		TO 'root'@'localhost' 
-		IDENTIFIED BY '{{MYSQL_ROOT_PASSWORD}}' 
-		WITH GRANT OPTION;
-		FLUSH PRIVILEGES;
-	EOT
-
 	MYSQL_INIT_SQL_DATABASE_TEMPLATE="-- Create database"
 	if [[ -n ${OPTS_MYSQL_USER_DATABASE} ]]; then
 		printf \
@@ -251,7 +230,13 @@ if ! is_mysql_data_directory_populated ${OPTS_MYSQL_DATA_DIR}; then
 		/tmp/mysql-init-template \
 		<<-EOT
 
-		${MYSQL_INIT_SQL_HEAD_TEMPLATE}
+		-- =============================================================================
+		-- Initialisation SQL
+		-- -----------------------------------------------------------------------------
+		-- Secure MySQL
+		DROP DATABASE IF EXISTS test;
+		DELETE FROM mysql.user WHERE User='' OR User='root' AND Host != 'localhost';
+		DELETE FROM mysql.db WHERE Db='test' OR Db='test\\_%';
 		${MYSQL_INIT_SQL_DATABASE_TEMPLATE}
 		${MYSQL_INIT_SQL_USER_TEMPLATE}
 		-- =============================================================================
@@ -262,7 +247,12 @@ if ! is_mysql_data_directory_populated ${OPTS_MYSQL_DATA_DIR}; then
 		-- Custom Initialisation SQL end
 		-- -----------------------------------------------------------------------------
 		${MYSQL_INIT_SQL_PRIVILEGES_TEMPLATE}
-		${MYSQL_INIT_SQL_TAIL_TEMPLATE}
+		GRANT ALL PRIVILEGES 
+		ON *.* 
+		TO 'root'@'localhost' 
+		IDENTIFIED BY '{{MYSQL_ROOT_PASSWORD}}' 
+		WITH GRANT OPTION;
+		FLUSH PRIVILEGES;
 	EOT
 
 	# Each statement must be on a single line and should not include comments.

--- a/usr/sbin/mysqld-bootstrap
+++ b/usr/sbin/mysqld-bootstrap
@@ -191,7 +191,9 @@ if ! is_mysql_data_directory_populated ${OPTS_MYSQL_DATA_DIR}; then
 	PIDS[0]=${!}
 
 	# Generate the initialisation SQL used secure MySQL
-	tee /tmp/mysql-init-template <<-EOT
+	tee \
+		/tmp/mysql-init-template \
+		<<-EOT
 
 		-- =============================================================================
 		-- Initialisation SQL
@@ -277,24 +279,23 @@ if ! is_mysql_data_directory_populated ${OPTS_MYSQL_DATA_DIR}; then
 			/tmp/mysql-init{,-template}
 	fi
 
-	DETAILS_MYSQL_USER_CREDENTIALS=
+	# Local root user details
+	printf \
+		-v DETAILS_MYSQL_USER_CREDENTIALS \
+		-- "user : %s@%s, password : %s" \
+		root \
+		localhost \
+		"${OPTS_MYSQL_ROOT_PASSWORD}"
+
 	if [[ -n ${OPTS_MYSQL_USER} ]] \
 		&& [[ -n ${OPTS_MYSQL_USER_PASSWORD} ]]; then
 		printf \
 			-v DETAILS_MYSQL_USER_CREDENTIALS \
-			-- "\nuser : %s@%s, password : %s" \
+			-- "%s\nuser : %s@%s, password : %s" \
+			"${DETAILS_MYSQL_USER_CREDENTIALS}" \
 			"${OPTS_MYSQL_USER}" \
 			"${OPTS_MYSQL_USER_HOST}" \
 			"${OPTS_MYSQL_USER_PASSWORD}"
-	fi
-
-	DETAILS_MYSQL_USER_DATABASE=
-	if [[ -n ${OPTS_MYSQL_USER_DATABASE} ]]; then
-		printf \
-			-v DETAILS_MYSQL_USER_DATABASE \
-			-- "\n%s : %s" \
-			"user database" \
-			"${OPTS_MYSQL_USER_DATABASE}"
 	fi
 
 	TIMER_TOTAL=$(
@@ -304,12 +305,14 @@ if ! is_mysql_data_directory_populated ${OPTS_MYSQL_DATA_DIR}; then
 		{ print T2 - T1; }"
 	)
 
-	cat <<-EOT
+	cat \
+		<<-EOT
 
 		================================================================================
 		MySQL Details
 		--------------------------------------------------------------------------------
-		user : root@localhost, password : ${OPTS_MYSQL_ROOT_PASSWORD}${DETAILS_MYSQL_USER_CREDENTIALS}${DETAILS_MYSQL_USER_DATABASE}
+		${DETAILS_MYSQL_USER_CREDENTIALS}
+		databases : ${OPTS_MYSQL_USER_DATABASE:-N/A}
 		--------------------------------------------------------------------------------
 		${TIMER_TOTAL}
 

--- a/usr/sbin/mysqld-bootstrap
+++ b/usr/sbin/mysqld-bootstrap
@@ -6,15 +6,38 @@ TIMER_START=$(
 
 source /etc/mysqld-bootstrap.conf
 
+get_mysql_user_host ()
+{
+	local CLIENT_SUBNET="${1:-127.0.0.1}"
+	local VALUE
+
+	case "${CLIENT_SUBNET}" in
+		0.0.0.0|0.0.0.0/0.0.0.0)
+			# Connect from any network
+			VALUE="%"
+			;;
+		127.0.0.1)
+			# Internal connection
+			VALUE="localhost"
+			;;
+		*)
+			# User defined host / subnet
+			VALUE="${CLIENT_SUBNET}"
+			;;
+	esac
+
+	printf -- "%s" "${VALUE}"
+}
+
 get_option ()
 {
-	local value=$(
+	local VALUE=$(
 		/usr/bin/my_print_defaults "${1}" | \
 		sed -n "s/^--${2}=//p" | \
 		tail -n 1
 	)
 
-	printf -- "%s" "${value:-$3}"
+	printf -- "%s" "${VALUE:-$3}"
 }
 
 get_password ()
@@ -97,22 +120,13 @@ if ! is_mysql_data_directory_populated ${OPTS_MYSQL_DATA_DIR}; then
 			"/var/run/mysqld/mysql.sock"
 	)"
 	OPTS_MYSQL_SOCKET_DIR="${OPTS_MYSQL_SOCKET%/*}"
-	OPTS_MYSQL_SUBNET="${MYSQL_SUBNET:-127.0.0.1}"
 	OPTS_MYSQL_USER="${MYSQL_USER:-}"
 	OPTS_MYSQL_USER_DATABASE="${MYSQL_USER_DATABASE:-}"
+	OPTS_MYSQL_USER_HOST="$(
+		get_mysql_user_host \
+		"${MYSQL_SUBNET:-127.0.0.1}"
+	)"
 	OPTS_MYSQL_USER_PASSWORD="${MYSQL_USER_PASSWORD:-$(get_password ${PASSWORD_LENGTH})}"
-
-	if [[ ${OPTS_MYSQL_SUBNET} == 0.0.0.0/0.0.0.0 ]] \
-		|| [[ ${OPTS_MYSQL_SUBNET} == 0.0.0.0 ]]; then
-		# Connect from any network
-		OPTS_MYSQL_USER_HOST=%
-	elif [[ ${OPTS_MYSQL_SUBNET} == 127.0.0.1 ]]; then
-		# Internal connection
-		OPTS_MYSQL_USER_HOST=localhost
-	else
-		# User defined host / subnet
-		OPTS_MYSQL_USER_HOST="${OPTS_MYSQL_SUBNET}"
-	fi
 
 	# Adjust the UID/GID values of the service user to match a directory that 
 	# could be a mounted volume
@@ -208,11 +222,11 @@ if ! is_mysql_data_directory_populated ${OPTS_MYSQL_DATA_DIR}; then
 		-e '/^[ \t]*--.*$/d' \
 		-e 's/;[ \t]*--.*$/;/g' \
 		-e '/^$/d' \
-		-e "s/{{MYSQL_ROOT_PASSWORD}}/${OPTS_MYSQL_ROOT_PASSWORD}/g" \
-		-e "s/{{MYSQL_USER}}/${OPTS_MYSQL_USER}/g" \
-		-e "s/{{MYSQL_USER_DATABASE}}/${OPTS_MYSQL_USER_DATABASE}/g" \
-		-e "s/{{MYSQL_USER_HOST}}/${OPTS_MYSQL_USER_HOST}/g" \
-		-e "s/{{MYSQL_USER_PASSWORD}}/${OPTS_MYSQL_USER_PASSWORD}/g" \
+		-e "s~{{MYSQL_ROOT_PASSWORD}}~${OPTS_MYSQL_ROOT_PASSWORD}~g" \
+		-e "s~{{MYSQL_USER}}~${OPTS_MYSQL_USER}~g" \
+		-e "s~{{MYSQL_USER_DATABASE}}~${OPTS_MYSQL_USER_DATABASE}~g" \
+		-e "s~{{MYSQL_USER_HOST}}~${OPTS_MYSQL_USER_HOST}~g" \
+		-e "s~{{MYSQL_USER_PASSWORD}}~${OPTS_MYSQL_USER_PASSWORD}~g" \
 		| \
 	awk \
 		'{ ORS=( /;$/ ? RS:FS ) } 1' \

--- a/usr/sbin/mysqld-bootstrap
+++ b/usr/sbin/mysqld-bootstrap
@@ -97,6 +97,22 @@ if ! is_mysql_data_directory_populated ${OPTS_MYSQL_DATA_DIR}; then
 			"/var/run/mysqld/mysql.sock"
 	)"
 	OPTS_MYSQL_SOCKET_DIR="${OPTS_MYSQL_SOCKET%/*}"
+	OPTS_MYSQL_SUBNET="${MYSQL_SUBNET:-127.0.0.1}"
+	OPTS_MYSQL_USER="${MYSQL_USER:-}"
+	OPTS_MYSQL_USER_DATABASE="${MYSQL_USER_DATABASE:-}"
+	OPTS_MYSQL_USER_PASSWORD="${MYSQL_USER_PASSWORD:-$(get_password ${PASSWORD_LENGTH})}"
+
+	if [[ ${OPTS_MYSQL_SUBNET} == 0.0.0.0/0.0.0.0 ]] \
+		|| [[ ${OPTS_MYSQL_SUBNET} == 0.0.0.0 ]]; then
+		# Connect from any network
+		OPTS_MYSQL_USER_HOST=%
+	elif [[ ${OPTS_MYSQL_SUBNET} == 127.0.0.1 ]]; then
+		# Internal connection
+		OPTS_MYSQL_USER_HOST=localhost
+	else
+		# User defined host / subnet
+		OPTS_MYSQL_USER_HOST="${OPTS_MYSQL_SUBNET}"
+	fi
 
 	# Adjust the UID/GID values of the service user to match a directory that 
 	# could be a mounted volume
@@ -178,7 +194,7 @@ if ! is_mysql_data_directory_populated ${OPTS_MYSQL_DATA_DIR}; then
 		-- Custom Initialisation SQL end
 		-- -----------------------------------------------------------------------------
 		GRANT ALL PRIVILEGES ON *.* TO 'root'@'localhost' 
-		IDENTIFIED BY '${OPTS_MYSQL_ROOT_PASSWORD}' 
+		IDENTIFIED BY '{{MYSQL_ROOT_PASSWORD}}' 
 		WITH GRANT OPTION;
 		FLUSH PRIVILEGES;
 	EOT
@@ -192,6 +208,11 @@ if ! is_mysql_data_directory_populated ${OPTS_MYSQL_DATA_DIR}; then
 		-e '/^[ \t]*--.*$/d' \
 		-e 's/;[ \t]*--.*$/;/g' \
 		-e '/^$/d' \
+		-e "s/{{MYSQL_ROOT_PASSWORD}}/${OPTS_MYSQL_ROOT_PASSWORD}/g" \
+		-e "s/{{MYSQL_USER}}/${OPTS_MYSQL_USER}/g" \
+		-e "s/{{MYSQL_USER_DATABASE}}/${OPTS_MYSQL_USER_DATABASE}/g" \
+		-e "s/{{MYSQL_USER_HOST}}/${OPTS_MYSQL_USER_HOST}/g" \
+		-e "s/{{MYSQL_USER_PASSWORD}}/${OPTS_MYSQL_USER_PASSWORD}/g" \
 		| \
 	awk \
 		'{ ORS=( /;$/ ? RS:FS ) } 1' \
@@ -242,6 +263,26 @@ if ! is_mysql_data_directory_populated ${OPTS_MYSQL_DATA_DIR}; then
 			/tmp/mysql-init{,-template}
 	fi
 
+	DETAILS_MYSQL_USER_CREDENTIALS=
+	if [[ -n ${OPTS_MYSQL_USER} ]] \
+		&& [[ -n ${OPTS_MYSQL_USER_PASSWORD} ]]; then
+		printf \
+			-v DETAILS_MYSQL_USER_CREDENTIALS \
+			-- "\nuser : %s@%s, password : %s" \
+			"${OPTS_MYSQL_USER}" \
+			"${OPTS_MYSQL_USER_HOST}" \
+			"${OPTS_MYSQL_USER_PASSWORD}"
+	fi
+
+	DETAILS_MYSQL_USER_DATABASE=
+	if [[ -n ${OPTS_MYSQL_USER_DATABASE} ]]; then
+		printf \
+			-v DETAILS_MYSQL_USER_DATABASE \
+			-- "\n%s : %s" \
+			"user database" \
+			"${OPTS_MYSQL_USER_DATABASE}"
+	fi
+
 	TIMER_TOTAL=$(
 		echo - | awk "\
 		{ T1="${TIMER_START}" } \
@@ -252,9 +293,9 @@ if ! is_mysql_data_directory_populated ${OPTS_MYSQL_DATA_DIR}; then
 	cat <<-EOT
 
 		================================================================================
-		MySQL Credentials
+		MySQL Details
 		--------------------------------------------------------------------------------
-		root@localhost : ${OPTS_MYSQL_ROOT_PASSWORD}
+		user : root@localhost, password : ${OPTS_MYSQL_ROOT_PASSWORD}${DETAILS_MYSQL_USER_CREDENTIALS}${DETAILS_MYSQL_USER_DATABASE}
 		--------------------------------------------------------------------------------
 		${TIMER_TOTAL}
 


### PR DESCRIPTION
Resolves #77 
- Custom MySQL initialisation SQL can still be added to the configuration file but the SQL required to create the operator defined database, user and subnet (user host) is now handled in the bootstrap script so cannot be altered.
