### PR TITLE
Release changes ready for centos-6-1.6.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # CentOS-6, MySQL 5.1
 # 
 # =============================================================================
-FROM jdeathe/centos-ssh:centos-6-1.5.3
+FROM jdeathe/centos-ssh:centos-6-1.6.0
 
 MAINTAINER James Deathe <james.deathe@gmail.com>
 
@@ -22,20 +22,30 @@ RUN rpm --rebuilddb \
 # -----------------------------------------------------------------------------
 # Copy files into place
 # -----------------------------------------------------------------------------
-ADD usr/sbin/mysqld-bootstrap /usr/sbin/
+ADD usr/sbin \
+	/usr/sbin/
 ADD etc/services-config/mysql/my.cnf \
 	etc/services-config/mysql/mysqld-bootstrap.conf \
 	/etc/services-config/mysql/
-ADD etc/services-config/supervisor/supervisord.d/mysqld-bootstrap.conf \
-	etc/services-config/supervisor/supervisord.d/mysqld-wrapper.conf \
+ADD etc/services-config/supervisor/supervisord.d \
 	/etc/services-config/supervisor/supervisord.d/
 
-RUN ln -sf /etc/services-config/mysql/my.cnf /etc/my.cnf \
-	&& ln -sf /etc/services-config/mysql/mysqld-bootstrap.conf /etc/mysqld-bootstrap.conf \
-	&& ln -sf /etc/services-config/supervisor/supervisord.d/mysqld-bootstrap.conf /etc/supervisord.d/mysqld-bootstrap.conf \
-	&& ln -sf /etc/services-config/supervisor/supervisord.d/mysqld-wrapper.conf /etc/supervisord.d/mysqld-wrapper.conf \
-	&& chmod 600 /etc/services-config/mysql/{my.cnf,mysqld-bootstrap.conf} \
-	&& chmod 700 /usr/sbin/mysqld-bootstrap
+RUN ln -sf \
+		/etc/services-config/mysql/my.cnf \
+		/etc/my.cnf \
+	&& ln -sf \
+		/etc/services-config/mysql/mysqld-bootstrap.conf \
+		/etc/mysqld-bootstrap.conf \
+	&& ln -sf \
+		/etc/services-config/supervisor/supervisord.d/mysqld-bootstrap.conf \
+		/etc/supervisord.d/mysqld-bootstrap.conf \
+	&& ln -sf \
+		/etc/services-config/supervisor/supervisord.d/mysqld-wrapper.conf \
+		/etc/supervisord.d/mysqld-wrapper.conf \
+	&& chmod 600 \
+		/etc/services-config/mysql/{my.cnf,mysqld-bootstrap.conf} \
+	&& chmod 700 \
+		/usr/sbin/mysqld-bootstrap
 
 EXPOSE 3306
 

--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,6 @@ PREFIX_SUB_STEP_POSITIVE := $(shell printf -- '%b%s%b' "$(COLOUR_POSITIVE)" "$(P
 
 .DEFAULT_GOAL := build
 
-# Get absolute file paths
-PACKAGE_PATH := $(realpath $(PACKAGE_PATH))
-
 # Package prerequisites
 docker := $(shell type -p docker)
 xz := $(shell type -p xz)
@@ -54,6 +51,7 @@ get-docker-info := $(shell $(docker) info)
 	require-docker-container-status-running \
 	require-docker-image-tag \
 	require-docker-release-tag \
+	require-package-path \
 	restart \
 	rm \
 	rmi \
@@ -89,6 +87,7 @@ create: prerequisites require-docker-container-not
 	@ set -x; \
 		$(docker) create \
 			$(DOCKER_CONTAINER_PARAMETERS) \
+			$(DOCKER_CONTAINER_PARAMETERS_APPEND) \
 			$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG) 1> /dev/null;
 	@ if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=created") ]]; then \
 			echo "$(PREFIX_SUB_STEP) $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=created")"; \
@@ -98,23 +97,22 @@ create: prerequisites require-docker-container-not
 			exit 1; \
 		fi
 
-dist: prerequisites require-docker-release-tag | pull
-	@ if [[ -s $(PACKAGE_PATH)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz ]]; then \
+dist: prerequisites require-docker-release-tag require-package-path | pull
+	$(eval $@_package_path := $(realpath \
+		$(PACKAGE_PATH) \
+	))
+	@ if [[ -s $($@_package_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz ]]; then \
 			echo "$(PREFIX_STEP) Saving package"; \
-			echo "$(PREFIX_SUB_STEP) Package path: $(PACKAGE_PATH)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz"; \
+			echo "$(PREFIX_SUB_STEP) Package path: $($@_package_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz"; \
 			echo "$(PREFIX_SUB_STEP_POSITIVE) Package already exists"; \
 		else \
-			if [[ ! -d $(PACKAGE_PATH) ]]; then \
-				echo "$(PREFIX_STEP) Creating package directory"; \
-				mkdir -p $(PACKAGE_PATH); \
-			fi; \
 			echo "$(PREFIX_STEP) Saving package"; \
 			$(docker) save \
 				$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG) | \
 				$(xz) -9 > \
-					$(PACKAGE_PATH)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz; \
+					$($@_package_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz; \
 				if [[ $${?} -eq 0 ]]; then \
-					echo "$(PREFIX_SUB_STEP) Package path: $(PACKAGE_PATH)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz"; \
+					echo "$(PREFIX_SUB_STEP) Package path: $($@_package_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz"; \
 					echo "$(PREFIX_SUB_STEP_POSITIVE) Package saved"; \
 				else \
 					echo "$(PREFIX_SUB_STEP_NEGATIVE) Package save error"; \
@@ -122,14 +120,17 @@ dist: prerequisites require-docker-release-tag | pull
 				fi; \
 		fi
 
-distclean: prerequisites require-docker-release-tag | clean
-	@ if [[ -e $(PACKAGE_PATH)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz ]]; then \
+distclean: prerequisites require-docker-release-tag require-package-path | clean
+	$(eval $@_package_path := $(realpath \
+		$(PACKAGE_PATH) \
+	))
+	@ if [[ -e $($@_package_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz ]]; then \
 			echo "$(PREFIX_STEP) Deleting package"; \
-			echo "$(PREFIX_SUB_STEP) Package path: $(PACKAGE_PATH)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz"; \
-			find $(PACKAGE_PATH) \
+			echo "$(PREFIX_SUB_STEP) Package path: $($@_package_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz"; \
+			find $($@_package_path) \
 				-name $(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz \
 				-delete; \
-			if [[ ! -e $(PACKAGE_PATH)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz ]]; then \
+			if [[ ! -e $($@_package_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz ]]; then \
 				echo "$(PREFIX_SUB_STEP_POSITIVE) Package cleanup complete"; \
 			else \
 				echo "$(PREFIX_SUB_STEP_NEGATIVE) Package cleanup failed"; \
@@ -156,15 +157,18 @@ logs-delayed: prerequisites
 	@ sleep 2
 	@ $(MAKE) logs
 
-load: prerequisites require-docker-release-tag
+load: prerequisites require-docker-release-tag require-package-path
+	$(eval $@_package_path := $(realpath \
+		$(PACKAGE_PATH) \
+	))
 	@ echo "$(PREFIX_STEP) Loading image from package"; \
-		echo "$(PREFIX_SUB_STEP) Package path: $(PACKAGE_PATH)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz"; \
-		if [[ ! -s $(PACKAGE_PATH)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz ]]; then \
+		echo "$(PREFIX_SUB_STEP) Package path: $($@_package_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz"; \
+		if [[ ! -s $($@_package_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz ]]; then \
 			echo "$(PREFIX_STEP_NEGATIVE) Package not found"; \
 			echo "$(PREFIX_SUB_STEP_NEGATIVE) To create a package try: DOCKER_IMAGE_TAG=\"$(DOCKER_IMAGE_TAG)\" make dist"; \
 			exit 1; \
 		else \
-			$(xz) -dc $(PACKAGE_PATH)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz | \
+			$(xz) -dc $($@_package_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz | \
 				$(docker) load; \
 			echo "$(PREFIX_SUB_STEP) $$( if [[ -n $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)) ]]; then echo $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); else echo $$($(docker) images -q docker.io/$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); fi; )"; \
 			echo "$(PREFIX_SUB_STEP_POSITIVE) Image loaded"; \
@@ -265,6 +269,19 @@ require-docker-release-tag:
 			exit 1; \
 		fi
 
+require-package-path:
+	@ if [[ -n $(PACKAGE_PATH) ]] && [[ ! -d $(PACKAGE_PATH) ]]; then \
+			echo "$(PREFIX_STEP) Creating package directory"; \
+			mkdir -p $(PACKAGE_PATH); \
+		fi; \
+		if [[ ! $${?} -eq 0 ]]; then \
+			echo "$(PREFIX_STEP_NEGATIVE) Failed to make package path: $(PACKAGE_PATH)"; \
+			exit 1; \
+		elif [[ -z $(PACKAGE_PATH) ]]; then \
+			echo "$(PREFIX_STEP_NEGATIVE) Undefined PACKAGE_PATH"; \
+			exit 1; \
+		fi
+
 restart: prerequisites require-docker-container require-docker-container-not-status-paused
 	@ echo "$(PREFIX_STEP) Restarting container"
 	@ $(docker) restart $(DOCKER_NAME) 1> /dev/null
@@ -306,6 +323,7 @@ run: prerequisites require-docker-image-tag
 		$(docker) run \
 			--detach \
 			$(DOCKER_CONTAINER_PARAMETERS) \
+			$(DOCKER_CONTAINER_PARAMETERS_APPEND) \
 			$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG) 1> /dev/null;
 	@ if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=running") ]]; then \
 			echo "$(PREFIX_SUB_STEP) $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=running")"; \

--- a/README-short.txt
+++ b/README-short.txt
@@ -1,1 +1,1 @@
-CentOS-6 6.7 x86_64 / MySQL.
+CentOS-6 6.8 x86_64 / MySQL.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 centos-ssh-mysql
 ================
 
-Docker Image of CentOS-6 6.7 x86_64, MySQL 5.1.
+Docker Image of CentOS-6 6.8 x86_64, MySQL 5.1.
 
 Includes Automated password generation and an option for custom initialisation SQL. Supports custom configuration via environment variables and/or a configuration data volume.
 

--- a/environment.mk
+++ b/environment.mk
@@ -1,11 +1,19 @@
+# -----------------------------------------------------------------------------
+# Constants
+# -----------------------------------------------------------------------------
+DOCKER_USER := jdeathe
+DOCKER_IMAGE_NAME := centos-ssh-mysql
 
 # Tag validation patterns
 DOCKER_IMAGE_TAG_PATTERN := ^(latest|(centos-[6-7])|(centos-(6-1|7-2).[0-9]+.[0-9]+))$
 DOCKER_IMAGE_RELEASE_TAG_PATTERN := ^centos-(6-1|7-2).[0-9]+.[0-9]+$
 
+# -----------------------------------------------------------------------------
+# Variables
+# -----------------------------------------------------------------------------
+
 # Docker image/container settings
-DOCKER_USER := jdeathe
-DOCKER_IMAGE_NAME := centos-ssh-mysql
+DOCKER_CONTAINER_PARAMETERS_APPEND ?=
 DOCKER_IMAGE_TAG ?= latest
 DOCKER_NAME ?= mysql.pool-1.1.1
 DOCKER_PORT_MAP_TCP_22 ?= 
@@ -17,21 +25,6 @@ NO_CACHE ?= false
 
 # Directory path for release packages
 PACKAGE_PATH ?= ./packages/jdeathe
-
-# VOLUME_CONFIG_NAME := volume-config.${SERVICE_UNIT_NAME}
-# VOLUME_CONFIG_NAME := volume-config.${SERVICE_UNIT_NAME}.${SERVICE_UNIT_SHARED_GROUP}
-VOLUME_CONFIG_NAME := volume-config.mysql.pool-1.1.1
-
-# Use of a configuration volume requires additional maintenance and access to the
-# filesystem of the docker host so is disabled by default.
-VOLUME_CONFIG_ENABLED := false
-
-# Using named volumes allows for easier identification of files located in
-# /var/lib/docker/volumes/ on the docker host. If set to true, the value of
-# VOLUME_CONFIG_NAME is used in place of an automatically generated ID.
-# NOTE: When using named volumes you need to copy the contents of the directory
-# into the configuration "data" volume container.
-VOLUME_CONFIG_NAMED := false
 
 # ------------------------------------------------------------------------------
 # Application container configuration

--- a/mysql.pool-1.1.1@3306.service
+++ b/mysql.pool-1.1.1@3306.service
@@ -35,7 +35,7 @@ RestartSec=30
 TimeoutStartSec=1200
 Environment="DOCKER_IMAGE_PACKAGE_PATH=/var/services-packages"
 Environment="DOCKER_IMAGE_NAME=jdeathe/centos-ssh-mysql"
-Environment="DOCKER_IMAGE_TAG=centos-6-1.5.0"
+Environment="DOCKER_IMAGE_TAG=centos-6-1.6.0"
 Environment="DOCKER_PORT_MAP_TCP_3306=%i"
 Environment="SERVICE_UNIT_NAME=mysql"
 Environment="SERVICE_UNIT_APP_GROUP=app-1"

--- a/mysql.pool-1.register@.service
+++ b/mysql.pool-1.register@.service
@@ -65,13 +65,15 @@ ExecStartPre=/bin/bash -c \
 
 # Register service
 ExecStart=/bin/bash -c \
-  "while ! /usr/bin/etcdctl ${REGISTER_ETCD_PARAMETERS} get ${REGISTER_KEY_ROOT}/ports/tcp/3306 &> /dev/null; do \
-    /usr/bin/etcdctl \
-      ${REGISTER_ETCD_PARAMETERS} \
-      mk \
-      ${REGISTER_KEY_ROOT}/ports/tcp/3306 \
-      $(/usr/bin/sed 's/^[0-9.]*://' <<< $(if ! /usr/bin/docker port mysql.pool-1.%i 3306 &> /dev/null; then echo ''; else /usr/bin/docker port mysql.pool-1.%i 3306; fi)) \
-      --ttl ${REGISTER_TTL} 2> /dev/null; \
+  "until /usr/bin/etcdctl ${REGISTER_ETCD_PARAMETERS} get ${REGISTER_KEY_ROOT}/ports/tcp/3306 &> /dev/null; do \
+    if /usr/bin/docker port mysql.pool-1.%i 3306 &> /dev/null; then \
+      /usr/bin/etcdctl \
+        ${REGISTER_ETCD_PARAMETERS} \
+        mk \
+        ${REGISTER_KEY_ROOT}/ports/tcp/3306 \
+        \"$(/usr/bin/docker port mysql.pool-1.%i 3306 | /usr/bin/sed 's~^[0-9.]*:~~')\" \
+        --ttl ${REGISTER_TTL} 2> /dev/null; \
+    fi; \
     sleep 0.5; \
   done; \
   /usr/bin/etcdctl \
@@ -82,12 +84,14 @@ ExecStart=/bin/bash -c \
     --ttl ${REGISTER_TTL}; \
   while true; do \
     sleep ${REGISTER_UPDATE_INTERVAL}; \
-    /usr/bin/etcdctl \
-      ${REGISTER_ETCD_PARAMETERS} \
-      $(if ! /usr/bin/etcdctl ${REGISTER_ETCD_PARAMETERS} get ${REGISTER_KEY_ROOT}/ports/tcp/3306 &> /dev/null; then echo set; else echo update; fi) \
-      ${REGISTER_KEY_ROOT}/ports/tcp/3306 \
-      $(/usr/bin/sed 's/^[0-9.]*://' <<< $(if ! /usr/bin/docker port mysql.pool-1.%i 3306 &> /dev/null; then echo ''; else /usr/bin/docker port mysql.pool-1.%i 3306; fi)) \
-      --ttl ${REGISTER_TTL}; \
+    if /usr/bin/docker port mysql.pool-1.%i 3306 &> /dev/null; then \
+      /usr/bin/etcdctl \
+        ${REGISTER_ETCD_PARAMETERS} \
+        $(if ! /usr/bin/etcdctl ${REGISTER_ETCD_PARAMETERS} get ${REGISTER_KEY_ROOT}/ports/tcp/3306 &> /dev/null; then echo set; else echo update; fi) \
+        ${REGISTER_KEY_ROOT}/ports/tcp/3306 \
+        \"$(/usr/bin/docker port mysql.pool-1.%i 3306 | /usr/bin/sed 's~^[0-9.]*:~~')\" \
+        --ttl ${REGISTER_TTL}; \
+    fi; \
     /usr/bin/etcdctl \
       ${REGISTER_ETCD_PARAMETERS} \
       $(if ! /usr/bin/etcdctl ${REGISTER_ETCD_PARAMETERS} get ${REGISTER_KEY_ROOT}/hostname &> /dev/null; then echo set; else echo update; fi) \

--- a/mysql.pool-1@.service
+++ b/mysql.pool-1@.service
@@ -48,8 +48,9 @@ After=docker.service
 Restart=on-failure
 RestartSec=30
 TimeoutStartSec=1200
+Environment="DOCKER_USER=jdeathe"
+Environment="DOCKER_IMAGE_NAME=centos-ssh-mysql"
 Environment="DOCKER_IMAGE_PACKAGE_PATH=/var/services-packages"
-Environment="DOCKER_IMAGE_NAME=jdeathe/centos-ssh-mysql"
 Environment="DOCKER_IMAGE_TAG=centos-6-1.5.0"
 Environment="DOCKER_PORT_MAP_TCP_3306=3306"
 Environment="VOLUME_CONFIG_ENABLED=false"
@@ -66,11 +67,11 @@ Environment="MYSQL_USER_PASSWORD_HASHED=false"
 
 # Initialisation: Load image from local storage if available, otherwise pull.
 ExecStartPre=/bin/bash -c \
-  "if [[ -z $( if [[ -n $(/usr/bin/docker images -q ${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}) ]]; then echo $(/usr/bin/docker images -q ${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}); else echo $(/usr/bin/docker images -q docker.io/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}); fi; ) ]]; then \
-    if [[ -f ${DOCKER_IMAGE_PACKAGE_PATH}/${DOCKER_IMAGE_NAME}.${DOCKER_IMAGE_TAG}.tar.xz ]]; then \
-      /usr/bin/xz -dc ${DOCKER_IMAGE_PACKAGE_PATH}/${DOCKER_IMAGE_NAME}.${DOCKER_IMAGE_TAG}.tar.xz | /usr/bin/docker load; \
+  "if [[ -z $( if [[ -n $(/usr/bin/docker images -q ${DOCKER_USER}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}) ]]; then echo $(/usr/bin/docker images -q ${DOCKER_USER}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}); else echo $(/usr/bin/docker images -q docker.io/${DOCKER_USER}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}); fi; ) ]]; then \
+    if [[ -f ${DOCKER_IMAGE_PACKAGE_PATH}/${DOCKER_USER}/${DOCKER_IMAGE_NAME}.${DOCKER_IMAGE_TAG}.tar.xz ]]; then \
+      /usr/bin/xz -dc ${DOCKER_IMAGE_PACKAGE_PATH}/${DOCKER_USER}/${DOCKER_IMAGE_NAME}.${DOCKER_IMAGE_TAG}.tar.xz | /usr/bin/docker load; \
     else \
-      /usr/bin/docker pull ${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}; \
+      /usr/bin/docker pull ${DOCKER_USER}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}; \
     fi; \
   fi"
 

--- a/mysql.pool-1@.service
+++ b/mysql.pool-1@.service
@@ -51,7 +51,7 @@ TimeoutStartSec=1200
 Environment="DOCKER_USER=jdeathe"
 Environment="DOCKER_IMAGE_NAME=centos-ssh-mysql"
 Environment="DOCKER_IMAGE_PACKAGE_PATH=/var/services-packages"
-Environment="DOCKER_IMAGE_TAG=centos-6-1.5.0"
+Environment="DOCKER_IMAGE_TAG=centos-6-1.6.0"
 Environment="DOCKER_PORT_MAP_TCP_3306=3306"
 Environment="VOLUME_CONFIG_ENABLED=false"
 Environment="VOLUME_CONFIG_NAMED=false"


### PR DESCRIPTION
- Updates upstream source to 1.6.0 tag (i.e. CentOS-6.8).
- Improves readability of Dockerfile.
- Updates Makefile to fix issue running `make dist` without first creating the `PACKAGE_PATH`, (./packages/jdeathe), directory.
- Adds `DOCKER_CONTAINER_PARAMETERS_APPEND` to the Makefile create template.
- Adds an improvements to the optional etcd register template unit-file used in systemd installations.
- Adds `DOCKER_USER` to the systemd template unit-file environment variables and removes the docker username from the `DOCKER_IMAGE_NAME` for consistency.
