### PR TITLE
CLOSES #104: Adds correct path to scmi on image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,14 +69,14 @@ ENV MYSQL_ROOT_PASSWORD="" \
 # -----------------------------------------------------------------------------
 # Set image metadata
 # -----------------------------------------------------------------------------
-ARG RELEASE_VERSION="1.7.0"
+ARG RELEASE_VERSION="1.7.1"
 LABEL \
 	install="docker run \
 --rm \
 --privileged \
 --volume /:/media/root \
 jdeathe/centos-ssh-mysql:centos-6-${RELEASE_VERSION} \
-/sbin/scmi install \
+/usr/sbin/scmi install \
 --chroot=/media/root \
 --name=\${NAME} \
 --tag=centos-6-${RELEASE_VERSION} \
@@ -86,7 +86,7 @@ jdeathe/centos-ssh-mysql:centos-6-${RELEASE_VERSION} \
 --privileged \
 --volume /:/media/root \
 jdeathe/centos-ssh-mysql:centos-6-${RELEASE_VERSION} \
-/sbin/scmi uninstall \
+/usr/sbin/scmi uninstall \
 --chroot=/media/root \
 --name=\${NAME} \
 --tag=centos-6-${RELEASE_VERSION} \

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ $ docker exec -it  mysql.pool-1.1.1 \
 
 ### Running
 
-To run the a docker container from this image you can use the standard docker commands. Alternatively, you can use the embedded (Service Container Manager Interface) [scmi](https://github.com/jdeathe/centos-ssh-mysql/blob/centos-6/usr/sbin/scmi) that is included in the image since `centos-6-1.7.0` or, if you have a checkout of the [source repository](https://github.com/jdeathe/centos-ssh-mysql), and have make installed the Makefile provides targets to build, install, start, stop etc. where environment variables can be used to configure the container options and set custom docker run parameters.
+To run the a docker container from this image you can use the standard docker commands. Alternatively, you can use the embedded (Service Container Manager Interface) [scmi](https://github.com/jdeathe/centos-ssh-mysql/blob/centos-6/usr/sbin/scmi) that is included in the image since `centos-6-1.7.1` or, if you have a checkout of the [source repository](https://github.com/jdeathe/centos-ssh-mysql), and have make installed the Makefile provides targets to build, install, start, stop etc. where environment variables can be used to configure the container options and set custom docker run parameters.
 
 #### SCMI Installation Examples
 
@@ -108,10 +108,10 @@ $ docker run \
   --rm \
   --privileged \
   --volume /:/media/root \
-  jdeathe/centos-ssh-mysql:centos-6-1.7.0 \
+  jdeathe/centos-ssh-mysql:centos-6-1.7.1 \
   /sbin/scmi install \
     --chroot=/media/root \
-    --tag=centos-6-1.7.0 \
+    --tag=centos-6-1.7.1 \
     --name=mysql.pool-1.1.1 \
     --setopt='--volume {{NAME}}.data-mysql:/var/lib/mysql'
 ```
@@ -125,10 +125,10 @@ $ docker run \
   --rm \
   --privileged \
   --volume /:/media/root \
-  jdeathe/centos-ssh-mysql:centos-6-1.7.0 \
+  jdeathe/centos-ssh-mysql:centos-6-1.7.1 \
   /sbin/scmi uninstall \
     --chroot=/media/root \
-    --tag=centos-6-1.7.0 \
+    --tag=centos-6-1.7.1 \
     --name=mysql.pool-1.1.1 \
     --setopt='--volume {{NAME}}.data-mysql:/var/lib/mysql'
 ```
@@ -142,10 +142,10 @@ $ docker run \
   --rm \
   --privileged \
   --volume /:/media/root \
-  jdeathe/centos-ssh-mysql:centos-6-1.7.0 \
+  jdeathe/centos-ssh-mysql:centos-6-1.7.1 \
   /sbin/scmi install \
     --chroot=/media/root \
-    --tag=centos-6-1.7.0 \
+    --tag=centos-6-1.7.1 \
     --name=mysql.pool-1.1.1 \
     --manager=systemd \
     --register \
@@ -162,7 +162,7 @@ If your docker host has systemd, fleetd (and optionally etcd) installed then `sc
 
 ##### SCMI Image Information
 
-Since release `centos-6-1.7.0` the install template has been added to the image metadata. Using docker inspect you can access `scmi` to simplify install/uninstall tasks.
+Since release `centos-6-1.7.1` the install template has been added to the image metadata. Using docker inspect you can access `scmi` to simplify install/uninstall tasks.
 
 To see detailed information about the image run `scmi` with the `--info` option. To see all available `scmi` options run with the `--help` option.
 
@@ -170,7 +170,7 @@ To see detailed information about the image run `scmi` with the `--info` option.
 $ eval "sudo -E $(
     docker inspect \
     -f "{{.ContainerConfig.Labels.install}}" \
-    jdeathe/centos-ssh-mysql:centos-6-1.7.0
+    jdeathe/centos-ssh-mysql:centos-6-1.7.1
   ) --info"
 ```
 
@@ -180,7 +180,7 @@ To perform an installation using the docker name `mysql.pool-1.2.1` simply use t
 $ eval "sudo -E $(
     docker inspect \
     -f "{{.ContainerConfig.Labels.install}}" \
-    jdeathe/centos-ssh-mysql:centos-6-1.7.0
+    jdeathe/centos-ssh-mysql:centos-6-1.7.1
   ) --name=mysql.pool-1.2.1"
 ```
 
@@ -190,7 +190,7 @@ To uninstall use the *same command* that was used to install but with the `unins
 $ eval "sudo -E $(
     docker inspect \
     -f "{{.ContainerConfig.Labels.uninstall}}" \
-    jdeathe/centos-ssh-mysql:centos-6-1.7.0
+    jdeathe/centos-ssh-mysql:centos-6-1.7.1
   ) --name=mysql.pool-1.2.1"
 ```
 
@@ -203,7 +203,7 @@ To see detailed information about the image run `scmi` with the `--info` option.
 ```
 $ sudo -E atomic install \
   -n mysql.pool-1.3.1 \
-  jdeathe/centos-ssh-mysql:centos-6-1.7.0 \
+  jdeathe/centos-ssh-mysql:centos-6-1.7.1 \
   --info
 ```
 
@@ -212,14 +212,14 @@ To perform an installation using the docker name `mysql.pool-1.3.1` simply use t
 ```
 $ sudo -E atomic install \
   -n mysql.pool-1.3.1 \
-  jdeathe/centos-ssh-mysql:centos-6-1.7.0
+  jdeathe/centos-ssh-mysql:centos-6-1.7.1
 ```
 
 Alternatively, you could use the `scmi` options `--name` or `-n` for naming the container.
 
 ```
 $ sudo -E atomic install \
-  jdeathe/centos-ssh-mysql:centos-6-1.7.0 \
+  jdeathe/centos-ssh-mysql:centos-6-1.7.1 \
   --name mysql.pool-1.3.1
 ```
 
@@ -228,7 +228,7 @@ To uninstall use the *same command* that was used to install but with the `unins
 ```
 $ sudo -E atomic uninstall \
   -n mysql.pool-1.3.1 \
-  jdeathe/centos-ssh-mysql:centos-6-1.7.0
+  jdeathe/centos-ssh-mysql:centos-6-1.7.1
 ```
 
 #### Using environment variables


### PR DESCRIPTION
Resolves #104 
- Updates the install/uninstall metadata labels to use the correct path to the scmi script on the image to allow the atomic install/uninstall feature to work as expected.
- Updates README examples to use the 1.7.1 release version.
