### PR TITLE
CLOSES #111: Updates source image to centos-6-1.7.3 release.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 packages
+dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # CentOS-6, MySQL 5.1
 # 
 # =============================================================================
-FROM jdeathe/centos-ssh:centos-6-1.7.0
+FROM jdeathe/centos-ssh:centos-6-1.7.3
 
 MAINTAINER James Deathe <james.deathe@gmail.com>
 

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ create: prerequisites require-docker-container-not
 		$(docker) create \
 			$(DOCKER_CONTAINER_PARAMETERS) \
 			$(DOCKER_PUBLISH) \
-			$(DOCKER_CONTAINER_PARAMETERS_APPEND) \
+			$(DOCKER_CONTAINER_OPTS) \
 			$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG) 1> /dev/null;
 	@ if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=created") ]]; then \
 			echo "$(PREFIX_SUB_STEP) $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=created")"; \
@@ -325,7 +325,7 @@ run: prerequisites require-docker-image-tag
 			--detach \
 			$(DOCKER_CONTAINER_PARAMETERS) \
 			$(DOCKER_PUBLISH) \
-			$(DOCKER_CONTAINER_PARAMETERS_APPEND) \
+			$(DOCKER_CONTAINER_OPTS) \
 			$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG) 1> /dev/null;
 	@ if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=running") ]]; then \
 			echo "$(PREFIX_SUB_STEP) $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=running")"; \

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,68 @@
 export SHELL := /usr/bin/env bash
 export PATH := ${PATH}
 
+define USAGE
+Usage: make [options] [target] ...
+Usage: VARIABLE="VALUE" make [options] -- [target] ...
+
+This Makefile allows you to build, operate and create release packages for the
+container image defined by the Dockerfile.
+
+Targets:
+  all                       Combines targets build images install start and ps.
+  build                     Builds the image. This is the default target.
+  clean                     Clean up build artifacts.
+  create                    Execute the create container template.
+  dist                      Pull a release version from the registry and save a
+                            package suitable for offline distribution. Image is 
+                            saved as a tar archive, compressed with xz.
+  distclean                 Clean up distribution artifacts.
+  exec COMMAND [ARG...]     Run command in a the running container.
+  help                      Show this help.
+  install                   Terminate running container and run the docker 
+                            create template.
+  images                    Show container's image details.
+  load                      Loads from the distribution package. Requires 
+                            DOCKER_IMAGE_TAG variable.
+  logs                      Display log output from the running container.
+  logs-delayed              Display log output from the running container after
+                            backing off shortly. This can be necessary when 
+                            chaining make targets together.
+  pause                     Pause the running container.
+  pull                      Pull the release image from the registry. Requires 
+                            the DOCKER_IMAGE_TAG variable.
+  ps                        Display the details of the container process.
+  restart                   Restarts the container.
+  rm                        Force remove the container.
+  rmi                       Untag (remove) the image.
+  run                       Execute the run container template.
+  start                     Start the container in the created state.
+  stop                      Stop the container when in a running state.
+  terminate                 Unpause, stop and remove the container.
+  unpause                   Unpause the container when in a paused state.
+
+Variables:
+  - DOCKER_CONTAINER_OPTS   Set optional docker parameters to append that will 
+                            be appended to the create and run templates.
+  - DOCKER_IMAGE_TAG        Defines the image tag name.
+  - DOCKER_NAME             Container name. The required format is as follows
+                            where <instance> and <node> are required numeric
+                            values and group is optional. 
+                            {<name>|<name>.[group]}.<instance>.<node>
+  - DOCKER_PORT_MAP_TCP_*   The port map variable is used to define the initial 
+                            port mapping to use for the docker host value where  
+                            "*" corresponds to an exposed port on the container.
+                            Setting this to an empty string or 0 will result in 
+                            an automatically assigned port and setting to NULL 
+                            will prevent the port from being published.
+  - DOCKER_RESTART_POLICY   Defines the container restart policy. 
+  - DIST_PATH               Ouput directory path - where the release package 
+                            artifacts are placed.
+  - NO_CACHE                When true, no cache will be used while running the 
+                            build target.
+
+endef
+
 include environment.mk
 include default.mk
 
@@ -9,23 +71,67 @@ COLOUR_NEGATIVE := \033[1;31m
 COLOUR_POSITIVE := \033[1;32m
 COLOUR_RESET := \033[0m
 CHARACTER_STEP := --->
-PREFIX_STEP := $(shell printf -- '%s ' "$(CHARACTER_STEP)")
-PREFIX_SUB_STEP := $(shell printf -- ' %s ' "$(CHARACTER_STEP)")
-PREFIX_STEP_NEGATIVE := $(shell printf -- '%b%s%b' "$(COLOUR_NEGATIVE)" "$(PREFIX_STEP)" "$(COLOUR_RESET)")
-PREFIX_STEP_POSITIVE := $(shell printf -- '%b%s%b' "$(COLOUR_POSITIVE)" "$(PREFIX_STEP)" "$(COLOUR_RESET)")
-PREFIX_SUB_STEP_NEGATIVE := $(shell printf -- '%b%s%b' "$(COLOUR_NEGATIVE)" "$(PREFIX_SUB_STEP)" "$(COLOUR_RESET)")
-PREFIX_SUB_STEP_POSITIVE := $(shell printf -- '%b%s%b' "$(COLOUR_POSITIVE)" "$(PREFIX_SUB_STEP)" "$(COLOUR_RESET)")
+PREFIX_STEP := $(shell \
+	printf -- '%s ' \
+		"$(CHARACTER_STEP)"; \
+)
+PREFIX_SUB_STEP := $(shell \
+	printf -- ' %s ' \
+		"$(CHARACTER_STEP)"; \
+)
+PREFIX_STEP_NEGATIVE := $(shell \
+	printf -- '%b%s%b' \
+		"$(COLOUR_NEGATIVE)" \
+		"$(PREFIX_STEP)" \
+		"$(COLOUR_RESET)"; \
+)
+PREFIX_STEP_POSITIVE := $(shell \
+	printf -- '%b%s%b' \
+		"$(COLOUR_POSITIVE)" \
+		"$(PREFIX_STEP)" \
+		"$(COLOUR_RESET)"; \
+)
+PREFIX_SUB_STEP_NEGATIVE := $(shell \
+	printf -- '%b%s%b' \
+		"$(COLOUR_NEGATIVE)" \
+		"$(PREFIX_SUB_STEP)" \
+		"$(COLOUR_RESET)"; \
+)
+PREFIX_SUB_STEP_POSITIVE := $(shell \
+	printf -- '%b%s%b' \
+		"$(COLOUR_POSITIVE)" \
+		"$(PREFIX_SUB_STEP)" \
+		"$(COLOUR_RESET)"; \
+)
 
 .DEFAULT_GOAL := build
 
 # Package prerequisites
-docker := $(shell type -p docker)
-xz := $(shell type -p xz)
+docker := $(shell \
+	type -p docker \
+)
+xz := $(shell \
+	type -p xz \
+)
 
 # Used to test docker host is accessible
-get-docker-info := $(shell $(docker) info)
+get-docker-info := $(shell \
+	$(docker) info \
+)
 
 .PHONY: \
+	_prerequisites \
+	_require-docker-container \
+	_require-docker-container-not \
+	_require-docker-container-not-status-paused \
+	_require-docker-container-status-created \
+	_require-docker-container-status-exited \
+	_require-docker-container-status-paused \
+	_require-docker-container-status-running \
+	_require-docker-image-tag \
+	_require-docker-release-tag \
+	_require-package-path \
+	_usage \
 	all \
 	build \
 	clean \
@@ -33,25 +139,15 @@ get-docker-info := $(shell $(docker) info)
 	dist \
 	distclean \
 	exec \
+	help \
 	install \
 	images \
 	load \
 	logs \
 	logs-delayed \
 	pause \
-	prerequisites \
 	pull \
 	ps \
-	require-docker-container \
-	require-docker-container-not \
-	require-docker-container-not-status-paused \
-	require-docker-container-status-created \
-	require-docker-container-status-exited \
-	require-docker-container-status-paused \
-	require-docker-container-status-running \
-	require-docker-image-tag \
-	require-docker-release-tag \
-	require-package-path \
 	restart \
 	rm \
 	rmi \
@@ -61,10 +157,101 @@ get-docker-info := $(shell $(docker) info)
 	terminate \
 	unpause
 
-all: prerequisites | build images install start ps
+_prerequisites:
+ifeq ($(docker),)
+	$(error "Please install the docker (docker-engine) package.")
+endif
+
+ifeq ($(xz),)
+	$(error "Please install the xz package.")
+endif
+
+ifeq ($(get-docker-info),)
+	$(error "Unable to connect to docker host.")
+endif
+
+_require-docker-container:
+	@ if [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)") ]]; then \
+			echo "$(PREFIX_STEP_NEGATIVE) This operation requires the $(DOCKER_NAME) docker container."; \
+			echo "$(PREFIX_SUB_STEP) Try installing it with: make install"; \
+			exit 1; \
+		fi
+
+_require-docker-container-not:
+	@ if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)") ]]; then \
+			echo "$(PREFIX_STEP_NEGATIVE) This operation requires the $(DOCKER_NAME) docker container be removed (or renamed)."; \
+			echo "$(PREFIX_SUB_STEP) Try removing it with: make rm"; \
+			exit 1; \
+		fi
+
+_require-docker-container-not-status-paused:
+	@ if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=paused") ]]; then \
+			echo "$(PREFIX_STEP_NEGATIVE) This operation requires the $(DOCKER_NAME) docker container to be unpaused."; \
+			echo "$(PREFIX_SUB_STEP) Try unpausing it with: make unpause"; \
+			exit 1; \
+		fi
+
+_require-docker-container-status-created:
+	@ if [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=created") ]]; then \
+			echo "$(PREFIX_STEP_NEGATIVE) This operation requires the $(DOCKER_NAME) docker container to be created."; \
+			echo "$(PREFIX_SUB_STEP) Try installing it with: make install"; \
+			exit 1; \
+		fi
+
+_require-docker-container-status-exited:
+	@ if [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=exited") ]]; then \
+			echo "$(PREFIX_STEP_NEGATIVE) This operation requires the $(DOCKER_NAME) docker container to be exited."; \
+			echo "$(PREFIX_SUB_STEP) Try stopping it with: make stop"; \
+			exit 1; \
+		fi
+
+_require-docker-container-status-paused:
+	@ if [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=paused") ]]; then \
+			echo "$(PREFIX_STEP_NEGATIVE) This operation requires the $(DOCKER_NAME) docker container to be paused."; \
+			echo "$(PREFIX_SUB_STEP) Try pausing it with: make pause"; \
+			exit 1; \
+		fi
+
+_require-docker-container-status-running:
+	@ if [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=running") ]]; then \
+			echo "$(PREFIX_STEP_NEGATIVE) This operation requires the $(DOCKER_NAME) docker container to be running."; \
+			echo "$(PREFIX_SUB_STEP) Try starting it with: make start"; \
+			exit 1; \
+		fi
+
+_require-docker-image-tag:
+	@ if [[ -z $$(if [[ $(DOCKER_IMAGE_TAG) =~ $(DOCKER_IMAGE_TAG_PATTERN) ]]; then echo $(DOCKER_IMAGE_TAG); else echo ''; fi) ]]; then \
+			echo "$(PREFIX_STEP_NEGATIVE) Invalid DOCKER_IMAGE_TAG value: $(DOCKER_IMAGE_TAG)"; \
+			exit 1; \
+		fi
+
+_require-docker-release-tag:
+	@ if [[ -z $$(if [[ $(DOCKER_IMAGE_TAG) =~ $(DOCKER_IMAGE_RELEASE_TAG_PATTERN) ]]; then echo $(DOCKER_IMAGE_TAG); else echo ''; fi) ]]; then \
+			echo "$(PREFIX_STEP_NEGATIVE) Invalid DOCKER_IMAGE_TAG value: $(DOCKER_IMAGE_TAG)"; \
+			echo "$(PREFIX_SUB_STEP) A release tag is required for this operation."; \
+			exit 1; \
+		fi
+
+_require-package-path:
+	@ if [[ -n $(DIST_PATH) ]] && [[ ! -d $(DIST_PATH) ]]; then \
+			echo "$(PREFIX_STEP) Creating package directory"; \
+			mkdir -p $(DIST_PATH); \
+		fi; \
+		if [[ ! $${?} -eq 0 ]]; then \
+			echo "$(PREFIX_STEP_NEGATIVE) Failed to make package path: $(DIST_PATH)"; \
+			exit 1; \
+		elif [[ -z $(DIST_PATH) ]]; then \
+			echo "$(PREFIX_STEP_NEGATIVE) Undefined DIST_PATH"; \
+			exit 1; \
+		fi
+
+_usage:
+	@: $(info $(USAGE))
+
+all: _prerequisites | build images install start ps
 
 # build NO_CACHE=[{false,true}]
-build: prerequisites require-docker-image-tag
+build: _prerequisites _require-docker-image-tag
 	@ echo "$(PREFIX_STEP) Building $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)"
 	@ if [[ $(NO_CACHE) == true ]]; then \
 			echo "$(PREFIX_SUB_STEP) Skipping cache"; \
@@ -80,9 +267,9 @@ build: prerequisites require-docker-image-tag
 			exit 1; \
 		fi
 
-clean: prerequisites | terminate rmi
+clean: _prerequisites | terminate rmi
 
-create: prerequisites require-docker-container-not
+create: _prerequisites _require-docker-container-not
 	@ echo "$(PREFIX_STEP) Creating container"
 	@ set -x; \
 		$(docker) create \
@@ -98,22 +285,22 @@ create: prerequisites require-docker-container-not
 			exit 1; \
 		fi
 
-dist: prerequisites require-docker-release-tag require-package-path | pull
-	$(eval $@_package_path := $(realpath \
+dist: _prerequisites _require-docker-release-tag _require-package-path | pull
+	$(eval $@_dist_path := $(realpath \
 		$(DIST_PATH) \
 	))
-	@ if [[ -s $($@_package_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz ]]; then \
+	@ if [[ -s $($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz ]]; then \
 			echo "$(PREFIX_STEP) Saving package"; \
-			echo "$(PREFIX_SUB_STEP) Package path: $($@_package_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz"; \
+			echo "$(PREFIX_SUB_STEP) Package path: $($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz"; \
 			echo "$(PREFIX_SUB_STEP_POSITIVE) Package already exists"; \
 		else \
 			echo "$(PREFIX_STEP) Saving package"; \
 			$(docker) save \
 				$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG) | \
 				$(xz) -9 > \
-					$($@_package_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz; \
+					$($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz; \
 				if [[ $${?} -eq 0 ]]; then \
-					echo "$(PREFIX_SUB_STEP) Package path: $($@_package_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz"; \
+					echo "$(PREFIX_SUB_STEP) Package path: $($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz"; \
 					echo "$(PREFIX_SUB_STEP_POSITIVE) Package saved"; \
 				else \
 					echo "$(PREFIX_SUB_STEP_NEGATIVE) Package save error"; \
@@ -121,17 +308,17 @@ dist: prerequisites require-docker-release-tag require-package-path | pull
 				fi; \
 		fi
 
-distclean: prerequisites require-docker-release-tag require-package-path | clean
-	$(eval $@_package_path := $(realpath \
+distclean: _prerequisites _require-docker-release-tag _require-package-path | clean
+	$(eval $@_dist_path := $(realpath \
 		$(DIST_PATH) \
 	))
-	@ if [[ -e $($@_package_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz ]]; then \
+	@ if [[ -e $($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz ]]; then \
 			echo "$(PREFIX_STEP) Deleting package"; \
-			echo "$(PREFIX_SUB_STEP) Package path: $($@_package_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz"; \
-			find $($@_package_path) \
+			echo "$(PREFIX_SUB_STEP) Package path: $($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz"; \
+			find $($@_dist_path) \
 				-name $(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz \
 				-delete; \
-			if [[ ! -e $($@_package_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz ]]; then \
+			if [[ ! -e $($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz ]]; then \
 				echo "$(PREFIX_SUB_STEP_POSITIVE) Package cleanup complete"; \
 			else \
 				echo "$(PREFIX_SUB_STEP_NEGATIVE) Package cleanup failed"; \
@@ -141,59 +328,48 @@ distclean: prerequisites require-docker-release-tag require-package-path | clean
 			echo "$(PREFIX_STEP) Package cleanup skipped"; \
 		fi
 
-exec: prerequisites
+exec: _prerequisites
 	@ $(docker) exec -it $(DOCKER_NAME) $(filter-out $@, $(MAKECMDGOALS))
 %:; @:
 
-images: prerequisites
+images: _prerequisites
 	@ $(docker) images \
 			$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG);
 
-install: | prerequisites terminate create
+help: _usage
 
-logs: prerequisites
+install: | _prerequisites terminate create
+
+logs: _prerequisites
 	@ $(docker) logs $(DOCKER_NAME)
 
-logs-delayed: prerequisites
+logs-delayed: _prerequisites
 	@ sleep 2
 	@ $(MAKE) logs
 
-load: prerequisites require-docker-release-tag require-package-path
-	$(eval $@_package_path := $(realpath \
+load: _prerequisites _require-docker-release-tag _require-package-path
+	$(eval $@_dist_path := $(realpath \
 		$(DIST_PATH) \
 	))
 	@ echo "$(PREFIX_STEP) Loading image from package"; \
-		echo "$(PREFIX_SUB_STEP) Package path: $($@_package_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz"; \
-		if [[ ! -s $($@_package_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz ]]; then \
+		echo "$(PREFIX_SUB_STEP) Package path: $($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz"; \
+		if [[ ! -s $($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz ]]; then \
 			echo "$(PREFIX_STEP_NEGATIVE) Package not found"; \
 			echo "$(PREFIX_SUB_STEP_NEGATIVE) To create a package try: DOCKER_IMAGE_TAG=\"$(DOCKER_IMAGE_TAG)\" make dist"; \
 			exit 1; \
 		else \
-			$(xz) -dc $($@_package_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz | \
+			$(xz) -dc $($@_dist_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz | \
 				$(docker) load; \
 			echo "$(PREFIX_SUB_STEP) $$( if [[ -n $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)) ]]; then echo $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); else echo $$($(docker) images -q docker.io/$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); fi; )"; \
 			echo "$(PREFIX_SUB_STEP_POSITIVE) Image loaded"; \
 		fi
 
-pause: prerequisites require-docker-container-status-running
+pause: _prerequisites _require-docker-container-status-running
 	@ echo "$(PREFIX_STEP) Pausing container"
 	@ $(docker) pause $(DOCKER_NAME) 1> /dev/null
 	@ echo "$(PREFIX_SUB_STEP_POSITIVE) Container paused"
 
-prerequisites:
-ifeq ($(docker),)
-	$(error "Please install the docker (docker-engine) package.")
-endif
-
-ifeq ($(xz),)
-	$(error "Please install the xz package.")
-endif
-
-ifeq ($(get-docker-info),)
-	$(error "Unable to connect to docker host.")
-endif
-
-pull: prerequisites require-docker-image-tag
+pull: _prerequisites _require-docker-image-tag
 	@ echo "$(PREFIX_STEP) Pulling image from registry"
 	@ $(docker) pull \
 			$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG); \
@@ -205,90 +381,15 @@ pull: prerequisites require-docker-image-tag
 			exit 1; \
 		fi
 
-ps: prerequisites require-docker-container
+ps: _prerequisites _require-docker-container
 	@ $(docker) ps -as --filter "name=$(DOCKER_NAME)";
 
-require-docker-container:
-	@ if [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)") ]]; then \
-			echo "$(PREFIX_STEP_NEGATIVE) This operation requires the $(DOCKER_NAME) docker container."; \
-			echo "$(PREFIX_SUB_STEP) Try installing it with: make install"; \
-			exit 1; \
-		fi
-
-require-docker-container-not:
-	@ if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)") ]]; then \
-			echo "$(PREFIX_STEP_NEGATIVE) This operation requires the $(DOCKER_NAME) docker container be removed (or renamed)."; \
-			echo "$(PREFIX_SUB_STEP) Try removing it with: make rm"; \
-			exit 1; \
-		fi
-
-require-docker-container-not-status-paused:
-	@ if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=paused") ]]; then \
-			echo "$(PREFIX_STEP_NEGATIVE) This operation requires the $(DOCKER_NAME) docker container to be unpaused."; \
-			echo "$(PREFIX_SUB_STEP) Try unpausing it with: make unpause"; \
-			exit 1; \
-		fi
-
-require-docker-container-status-created:
-	@ if [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=created") ]]; then \
-			echo "$(PREFIX_STEP_NEGATIVE) This operation requires the $(DOCKER_NAME) docker container to be created."; \
-			echo "$(PREFIX_SUB_STEP) Try installing it with: make install"; \
-			exit 1; \
-		fi
-
-require-docker-container-status-exited:
-	@ if [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=exited") ]]; then \
-			echo "$(PREFIX_STEP_NEGATIVE) This operation requires the $(DOCKER_NAME) docker container to be exited."; \
-			echo "$(PREFIX_SUB_STEP) Try stopping it with: make stop"; \
-			exit 1; \
-		fi
-
-require-docker-container-status-paused:
-	@ if [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=paused") ]]; then \
-			echo "$(PREFIX_STEP_NEGATIVE) This operation requires the $(DOCKER_NAME) docker container to be paused."; \
-			echo "$(PREFIX_SUB_STEP) Try pausing it with: make pause"; \
-			exit 1; \
-		fi
-
-require-docker-container-status-running:
-	@ if [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=running") ]]; then \
-			echo "$(PREFIX_STEP_NEGATIVE) This operation requires the $(DOCKER_NAME) docker container to be running."; \
-			echo "$(PREFIX_SUB_STEP) Try starting it with: make start"; \
-			exit 1; \
-		fi
-
-require-docker-image-tag:
-	@ if [[ -z $$(if [[ $(DOCKER_IMAGE_TAG) =~ $(DOCKER_IMAGE_TAG_PATTERN) ]]; then echo $(DOCKER_IMAGE_TAG); else echo ''; fi) ]]; then \
-			echo "$(PREFIX_STEP_NEGATIVE) Invalid DOCKER_IMAGE_TAG value: $(DOCKER_IMAGE_TAG)"; \
-			exit 1; \
-		fi
-
-require-docker-release-tag:
-	@ if [[ -z $$(if [[ $(DOCKER_IMAGE_TAG) =~ $(DOCKER_IMAGE_RELEASE_TAG_PATTERN) ]]; then echo $(DOCKER_IMAGE_TAG); else echo ''; fi) ]]; then \
-			echo "$(PREFIX_STEP_NEGATIVE) Invalid DOCKER_IMAGE_TAG value: $(DOCKER_IMAGE_TAG)"; \
-			echo "$(PREFIX_SUB_STEP) A release tag is required for this operation."; \
-			exit 1; \
-		fi
-
-require-package-path:
-	@ if [[ -n $(DIST_PATH) ]] && [[ ! -d $(DIST_PATH) ]]; then \
-			echo "$(PREFIX_STEP) Creating package directory"; \
-			mkdir -p $(DIST_PATH); \
-		fi; \
-		if [[ ! $${?} -eq 0 ]]; then \
-			echo "$(PREFIX_STEP_NEGATIVE) Failed to make package path: $(DIST_PATH)"; \
-			exit 1; \
-		elif [[ -z $(DIST_PATH) ]]; then \
-			echo "$(PREFIX_STEP_NEGATIVE) Undefined DIST_PATH"; \
-			exit 1; \
-		fi
-
-restart: prerequisites require-docker-container require-docker-container-not-status-paused
+restart: _prerequisites _require-docker-container _require-docker-container-not-status-paused
 	@ echo "$(PREFIX_STEP) Restarting container"
 	@ $(docker) restart $(DOCKER_NAME) 1> /dev/null
 	@ echo "$(PREFIX_SUB_STEP_POSITIVE) Container restarted"
 
-rm: prerequisites require-docker-container-not-status-paused
+rm: _prerequisites _require-docker-container-not-status-paused
 	@ if [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)") ]]; then \
 			echo "$(PREFIX_STEP) Container removal skipped"; \
 		else \
@@ -302,7 +403,7 @@ rm: prerequisites require-docker-container-not-status-paused
 			fi; \
 		fi
 
-rmi: prerequisites require-docker-image-tag require-docker-container-not
+rmi: _prerequisites _require-docker-image-tag _require-docker-container-not
 	@ if [[ -n $$( if [[ -n $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)) ]]; then echo $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); else echo $$($(docker) images -q docker.io/$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); fi; ) ]]; then \
 			echo "$(PREFIX_STEP) Untagging image"; \
 			echo "$(PREFIX_SUB_STEP) $$( if [[ -n $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)) ]]; then echo $$($(docker) images -q $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); else echo $$($(docker) images -q docker.io/$(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)); fi; ) : $(DOCKER_USER)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)"; \
@@ -318,7 +419,7 @@ rmi: prerequisites require-docker-image-tag require-docker-container-not
 			echo "$(PREFIX_STEP) Untagging image skipped"; \
 		fi
 
-run: prerequisites require-docker-image-tag
+run: _prerequisites _require-docker-image-tag
 	@ echo "$(PREFIX_STEP) Running container"
 	@ set -x; \
 		$(docker) run \
@@ -335,7 +436,7 @@ run: prerequisites require-docker-image-tag
 			exit 1; \
 		fi
 
-start: prerequisites require-docker-container require-docker-container-not-status-paused
+start: _prerequisites _require-docker-container _require-docker-container-not-status-paused
 	@ echo "$(PREFIX_STEP) Starting container"
 	@ if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)") ]] \
 			&& [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=running") ]]; then \
@@ -348,7 +449,7 @@ start: prerequisites require-docker-container require-docker-container-not-statu
 			exit 1; \
 		fi
 
-stop: prerequisites require-docker-container-not-status-paused require-docker-container-status-running
+stop: _prerequisites _require-docker-container-not-status-paused _require-docker-container-status-running
 	@ echo "$(PREFIX_STEP) Stopping container"
 	@ if [[ -n $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)" --filter "status=running") ]]; then \
 			$(docker) stop $(DOCKER_NAME) 1> /dev/null; \
@@ -360,7 +461,7 @@ stop: prerequisites require-docker-container-not-status-paused require-docker-co
 			fi; \
 		fi
 
-terminate: prerequisites
+terminate: _prerequisites
 	@ if [[ -z $$($(docker) ps -aq --filter "name=$(DOCKER_NAME)") ]]; then \
 			echo "$(PREFIX_STEP) Container termination skipped"; \
 		else \
@@ -385,7 +486,7 @@ terminate: prerequisites
 			fi; \
 		fi
 
-unpause: prerequisites require-docker-container-status-paused
+unpause: _prerequisites _require-docker-container-status-paused
 	@ echo "$(PREFIX_STEP) Unpausing container"
 	@ $(docker) unpause $(DOCKER_NAME) 1> /dev/null
 	@ echo "$(PREFIX_SUB_STEP_POSITIVE) Container unpaused"

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ create: prerequisites require-docker-container-not
 
 dist: prerequisites require-docker-release-tag require-package-path | pull
 	$(eval $@_package_path := $(realpath \
-		$(PACKAGE_PATH) \
+		$(DIST_PATH) \
 	))
 	@ if [[ -s $($@_package_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz ]]; then \
 			echo "$(PREFIX_STEP) Saving package"; \
@@ -123,7 +123,7 @@ dist: prerequisites require-docker-release-tag require-package-path | pull
 
 distclean: prerequisites require-docker-release-tag require-package-path | clean
 	$(eval $@_package_path := $(realpath \
-		$(PACKAGE_PATH) \
+		$(DIST_PATH) \
 	))
 	@ if [[ -e $($@_package_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz ]]; then \
 			echo "$(PREFIX_STEP) Deleting package"; \
@@ -160,7 +160,7 @@ logs-delayed: prerequisites
 
 load: prerequisites require-docker-release-tag require-package-path
 	$(eval $@_package_path := $(realpath \
-		$(PACKAGE_PATH) \
+		$(DIST_PATH) \
 	))
 	@ echo "$(PREFIX_STEP) Loading image from package"; \
 		echo "$(PREFIX_SUB_STEP) Package path: $($@_package_path)/$(DOCKER_IMAGE_NAME).$(DOCKER_IMAGE_TAG).tar.xz"; \
@@ -271,15 +271,15 @@ require-docker-release-tag:
 		fi
 
 require-package-path:
-	@ if [[ -n $(PACKAGE_PATH) ]] && [[ ! -d $(PACKAGE_PATH) ]]; then \
+	@ if [[ -n $(DIST_PATH) ]] && [[ ! -d $(DIST_PATH) ]]; then \
 			echo "$(PREFIX_STEP) Creating package directory"; \
-			mkdir -p $(PACKAGE_PATH); \
+			mkdir -p $(DIST_PATH); \
 		fi; \
 		if [[ ! $${?} -eq 0 ]]; then \
-			echo "$(PREFIX_STEP_NEGATIVE) Failed to make package path: $(PACKAGE_PATH)"; \
+			echo "$(PREFIX_STEP_NEGATIVE) Failed to make package path: $(DIST_PATH)"; \
 			exit 1; \
-		elif [[ -z $(PACKAGE_PATH) ]]; then \
-			echo "$(PREFIX_STEP_NEGATIVE) Undefined PACKAGE_PATH"; \
+		elif [[ -z $(DIST_PATH) ]]; then \
+			echo "$(PREFIX_STEP_NEGATIVE) Undefined DIST_PATH"; \
 			exit 1; \
 		fi
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ $ docker run \
   --privileged \
   --volume /:/media/root \
   jdeathe/centos-ssh-mysql:centos-6-1.7.1 \
-  /sbin/scmi install \
+  /usr/sbin/scmi install \
     --chroot=/media/root \
     --tag=centos-6-1.7.1 \
     --name=mysql.pool-1.1.1 \
@@ -126,7 +126,7 @@ $ docker run \
   --privileged \
   --volume /:/media/root \
   jdeathe/centos-ssh-mysql:centos-6-1.7.1 \
-  /sbin/scmi uninstall \
+  /usr/sbin/scmi uninstall \
     --chroot=/media/root \
     --tag=centos-6-1.7.1 \
     --name=mysql.pool-1.1.1 \
@@ -143,7 +143,7 @@ $ docker run \
   --privileged \
   --volume /:/media/root \
   jdeathe/centos-ssh-mysql:centos-6-1.7.1 \
-  /sbin/scmi install \
+  /usr/sbin/scmi install \
     --chroot=/media/root \
     --tag=centos-6-1.7.1 \
     --name=mysql.pool-1.1.1 \

--- a/environment.mk
+++ b/environment.mk
@@ -24,7 +24,7 @@ DOCKER_RESTART_POLICY ?= always
 NO_CACHE ?= false
 
 # Directory path for release packages
-PACKAGE_PATH ?= ./packages/jdeathe
+DIST_PATH ?= ./dist
 
 # -----------------------------------------------------------------------------
 # Application container configuration

--- a/environment.mk
+++ b/environment.mk
@@ -13,7 +13,7 @@ DOCKER_IMAGE_RELEASE_TAG_PATTERN := ^centos-(6-1|7-2).[0-9]+.[0-9]+$
 # -----------------------------------------------------------------------------
 
 # Docker image/container settings
-DOCKER_CONTAINER_PARAMETERS_APPEND ?=
+DOCKER_CONTAINER_OPTS ?=
 DOCKER_IMAGE_TAG ?= latest
 DOCKER_NAME ?= mysql.pool-1.1.1
 DOCKER_PORT_MAP_TCP_22 ?= NULL

--- a/etc/systemd/system/centos-ssh-mysql@.service
+++ b/etc/systemd/system/centos-ssh-mysql@.service
@@ -50,7 +50,7 @@ RestartSec=30
 TimeoutStartSec=1200
 Environment="DOCKER_USER=jdeathe"
 Environment="DOCKER_IMAGE_NAME=centos-ssh-mysql"
-Environment="DOCKER_CONTAINER_PARAMETERS_APPEND="
+Environment="DOCKER_CONTAINER_OPTS="
 Environment="DOCKER_IMAGE_PACKAGE_PATH=/var/opt/scmi/packages"
 Environment="DOCKER_IMAGE_TAG=centos-6-1.7.0"
 Environment="DOCKER_PORT_MAP_TCP_3306=3306"
@@ -109,7 +109,7 @@ ExecStart=/bin/bash -c \
         fi; \
       fi; \
     ) \
-    ${DOCKER_CONTAINER_PARAMETERS_APPEND} \
+    ${DOCKER_CONTAINER_OPTS} \
     ${DOCKER_USER}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}; \
   "
 

--- a/etc/systemd/system/centos-ssh-mysql@.service
+++ b/etc/systemd/system/centos-ssh-mysql@.service
@@ -119,6 +119,3 @@ ExecStop=/usr/bin/docker stop --time 10 %p.%i
 [Install]
 DefaultInstance=1.1
 WantedBy=multi-user.target
-
-[X-Fleet]
-Conflicts=%p@*.%i.service

--- a/opt/scmi/environment.sh
+++ b/opt/scmi/environment.sh
@@ -13,7 +13,7 @@ DOCKER_IMAGE_RELEASE_TAG_PATTERN='^centos-(6-1|7-2).[0-9]+.[0-9]+$'
 # -----------------------------------------------------------------------------
 
 # Docker image/container settings
-DOCKER_CONTAINER_PARAMETERS_APPEND="${DOCKER_CONTAINER_PARAMETERS_APPEND:-}"
+DOCKER_CONTAINER_OPTS="${DOCKER_CONTAINER_OPTS:-}"
 DOCKER_IMAGE_TAG="${DOCKER_IMAGE_TAG:-latest}"
 DOCKER_NAME="${DOCKER_NAME:-mysql.pool-1.1.1}"
 DOCKER_PORT_MAP_TCP_22="${DOCKER_PORT_MAP_TCP_22:-}"

--- a/opt/scmi/environment.sh
+++ b/opt/scmi/environment.sh
@@ -24,7 +24,7 @@ DOCKER_RESTART_POLICY="${DOCKER_RESTART_POLICY:-always}"
 NO_CACHE="${NO_CACHE:-false}"
 
 # Directory path for release packages
-PACKAGE_PATH="${PACKAGE_PATH:-./packages/jdeathe}"
+DIST_PATH="${DIST_PATH:-./dist}"
 
 # ETCD register service settings
 REGISTER_ETCD_PARAMETERS="${REGISTER_ETCD_PARAMETERS:-}"

--- a/opt/scmi/service-unit.sh
+++ b/opt/scmi/service-unit.sh
@@ -2,7 +2,7 @@
 # Constants
 # -----------------------------------------------------------------------------
 SERVICE_UNIT_ENVIRONMENT_KEYS="
- DOCKER_CONTAINER_PARAMETERS_APPEND
+ DOCKER_CONTAINER_OPTS
  DOCKER_IMAGE_PACKAGE_PATH
  DOCKER_IMAGE_TAG
  DOCKER_PORT_MAP_TCP_3306

--- a/usr/sbin/scmi
+++ b/usr/sbin/scmi
@@ -257,9 +257,9 @@ function scmi ()
 			fi
 
 			printf -v \
-				DOCKER_CONTAINER_PARAMETERS_APPEND \
+				DOCKER_CONTAINER_OPTS \
 				-- '%s %s' \
-				"${DOCKER_CONTAINER_PARAMETERS_APPEND}" \
+				"${DOCKER_CONTAINER_OPTS}" \
 				"$(
 					sed \
 						-e "s~{{NAME}}~${DOCKER_NAME}~g" \
@@ -372,7 +372,7 @@ function scmi_docker_get_create_template ()
 		'%s create %s %s %s/%s:%s' \
 		"${docker}" \
 		"${DOCKER_CONTAINER_PARAMETERS}" \
-		"${DOCKER_CONTAINER_PARAMETERS_APPEND}" \
+		"${DOCKER_CONTAINER_OPTS}" \
 		"${DOCKER_USER}" \
 		"${DOCKER_IMAGE_NAME}" \
 		"${DOCKER_IMAGE_TAG}"

--- a/usr/sbin/scmi
+++ b/usr/sbin/scmi
@@ -3,26 +3,28 @@
 # Change working directory
 cd -- "$(
 	dirname "${0}"
-)"
+)" || exit 1
 
 function scmi ()
 {
-	# Default settings
-	local SCMI_COMMAND=""
-	local SCMI_CHROOT_PATH="/"
-	declare -a local SCMI_ENV
-	local SCMI_IMAGE_PACKAGE_PATH="/var/opt/scmi/packages"
+	# Constants
 	local readonly SCMI_INCLUDE_FILES="
 	 environment.sh
 	 default.sh
 	 service-unit.sh
 	"
-	local SCMI_INFO=false
-	local SCMI_MANAGER_TYPE="docker"
 	local readonly SCMI_MANAGER_TYPE_PATTERN='^(docker|fleet|systemd)$'
-	local SCMI_NAME=""
 	local readonly SCMI_NAME_FORMAT='{<name>|<name>.[group]}.<instance>.<node>'
 	local readonly SCMI_PACKAGE_NAME="scmi"
+
+	# Default settings
+	local SCMI_COMMAND=""
+	local SCMI_CHROOT_PATH="/"
+	declare -a local SCMI_ENV
+	local SCMI_IMAGE_PACKAGE_PATH="/var/opt/scmi/packages"
+	local SCMI_INFO=false
+	local SCMI_MANAGER_TYPE="docker"
+	local SCMI_NAME=""
 	local SCMI_QUIET=false
 	local SCMI_REGISTER_ENABLED=false
 	local SCMI_RESTART=""
@@ -1648,11 +1650,13 @@ function scmi_systemd_get_template_unit_file_content ()
 			KEYS="SERVICE_UNIT_REGISTER_ENVIRONMENT_KEYS"
 
 			# Replace placehoder values
-			printf -v \
-				SED_COMMAND_LIST \
-				-- '%s -e %s' \
-				"${SED_COMMAND_LIST}" \
-				"\"s~{{SERVICE_UNIT_NAME}}~${SERVICE_UNIT_NAME}~g\""
+			if [[ -n ${SERVICE_UNIT_NAME} ]]; then
+				printf -v \
+					SED_COMMAND_LIST \
+					-- '%s -e %s' \
+					"${SED_COMMAND_LIST}" \
+					"\"s~{{SERVICE_UNIT_NAME}}~${SERVICE_UNIT_NAME}~g\""
+			fi
 
 			# Modify bound unit to allow fleetd to start|stop it directly.
 			if [[ ${SCMI_MANAGER_TYPE} == fleet ]]; then
@@ -2030,6 +2034,16 @@ function scmi_systemd_set_service_unit_names ()
 		expr \
 			"${DOCKER_NAME}" : \
 			'.*\.\([0-9][0-9]*\.[0-9][0-9]*\)'
+	)
+	SERVICE_UNIT_INSTANCE_LOCAL=$(
+		expr \
+			"${DOCKER_NAME}" : \
+			'.*\.\([0-9][0-9]*\)\.[0-9][0-9]*'
+	)
+	SERVICE_UNIT_INSTANCE_GLOBAL=$(
+		expr \
+			"${DOCKER_NAME}" : \
+			'.*\.[0-9][0-9]*\.\([0-9][0-9]*\)'
 	)
 
 	printf -v \


### PR DESCRIPTION
Resolves #111 
Resolves #110 
- Adds Makefile help target with usage instructions.
- Splits up the Makefile targets into internal and public types.
- Adds correct `scmi` path in usage instructions.
- Changes `PACKAGE_PATH` to `DIST_PATH` in line with the Makefile environment include. Not currently used by `scmi` but changing for consistency.
- Changes `DOCKER_CONTAINER_PARAMETERS_APPEND` to `DOCKER_CONTAINER_OPTS` for usability. This is a potentially breaking change that could affect systemd service configurations if using the Environment variable in a drop-in customisation. However, if using the systemd template unit-files it should be pinned to a specific version tag. The Makefile should only be used for development/testing and usage in `scmi` is internal only as the `--setopt` parameter is used to build up the optional container parameters. 
- Removes X-Fleet section from template unit-file.
