### PR TITLE
CLOSES #128: Removes undocumented MYSQL_DATA_DIR_DEFAULT variable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ CentOS-6 6.8 x86_64 - MySQL 5.1.
 ### 1.8.0 - Unreleased
 
 - Fixes issue with local readonly variables being writable.
+- Removes undocumented `MYSQL_DATA_DIR_DEFAULT` variable.
 
 ### 1.7.3 - 2017-05-12
 

--- a/etc/services-config/mysql/mysqld-bootstrap.conf
+++ b/etc/services-config/mysql/mysqld-bootstrap.conf
@@ -1,10 +1,5 @@
 #!/usr/bin/env bash
 
-# Used by the bootstrap script to determin if MySQL has been initialised. 
-# This value is used if there is no datadir found in the default configuration 
-# files.
-MYSQL_DATA_DIR_DEFAULT=/var/lib/mysql
-
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 # WARNING: Will destroy all existing data.
 # Set 1 to delete MySQL data directory and re-install on start.

--- a/usr/sbin/mysqld-bootstrap
+++ b/usr/sbin/mysqld-bootstrap
@@ -91,7 +91,7 @@ OPTS_MYSQL_DATA_DIR="$(
 	get_option \
 		mysqld \
 		datadir \
-		"${MYSQL_DATA_DIR_DEFAULT:-/var/lib/mysql}"
+		"/var/lib/mysql"
 )"
 OPTS_FORCE_MYSQL_INSTALL="${FORCE_MYSQL_INSTALL:-0}"
 


### PR DESCRIPTION
Resolves #128 

- Removes undocumented `MYSQL_DATA_DIR_DEFAULT` variable.