### PR TITLE
CLOSES #186: Updates source image to 2.4.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@
 
 Summary of release changes for Version 2.
 
-CentOS-7 7.4.1708 x86_64 - MySQL 5.7 Community Server.
+CentOS-7 7.5.1804 x86_64 - MySQL 5.7 Community Server.
+
+### 2.1.0 - Unreleased
+
+- Updates source image to [2.4.0](https://github.com/jdeathe/centos-ssh/releases/tag/2.4.0).
 
 ### 2.0.0 - 2018-08-07
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # CentOS-7, MySQL 5.7 Community Server
 # 
 # =============================================================================
-FROM jdeathe/centos-ssh:2.3.2
+FROM jdeathe/centos-ssh:2.4.0
 
 # -----------------------------------------------------------------------------
 # Install MySQL
@@ -112,7 +112,7 @@ jdeathe/centos-ssh-mysql:${RELEASE_VERSION} \
 	org.deathe.license="MIT" \
 	org.deathe.vendor="jdeathe" \
 	org.deathe.url="https://github.com/jdeathe/centos-ssh-mysql" \
-	org.deathe.description="CentOS-7 7.4.1708 x86_64 - MySQL 5.7 Community Server."
+	org.deathe.description="CentOS-7 7.5.1804 x86_64 - MySQL 5.7 Community Server."
 
 HEALTHCHECK \
 	--interval=1s \

--- a/README-short.txt
+++ b/README-short.txt
@@ -1,1 +1,1 @@
-CentOS-7 7.4.1708 x86_64 - MySQL Community Server.
+CentOS-7 7.5.1804 x86_64 - MySQL Community Server.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ centos-ssh-mysql
 
 Docker Image including:
 - CentOS-6 6.9 x86_64, MySQL 5.1.
-- CentOS-7 7.4.1708 x86_64, MySQL 5.7 Community Server.
+- CentOS-7 7.5.1804 x86_64, MySQL 5.7 Community Server.
 
 Includes Automated password generation and an option for custom initialisation SQL. Supports custom configuration via environment variables.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ centos-ssh-mysql
 ================
 
 Docker Image including:
-- CentOS-6 6.9 x86_64, MySQL 5.1.
+- CentOS-6 6.10 x86_64, MySQL 5.1.
 - CentOS-7 7.5.1804 x86_64, MySQL 5.7 Community Server.
 
 Includes Automated password generation and an option for custom initialisation SQL. Supports custom configuration via environment variables.


### PR DESCRIPTION
CLOSES #186 

- Updates source image to [2.4.0](https://github.com/jdeathe/centos-ssh/releases/tag/2.4.0).