### PR TITLE
CLOSES #185: Updates source image to 1.9.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@
 
 Summary of release changes for Version 1.
 
-CentOS-6 6.9 x86_64 - MySQL 5.1.
+CentOS-6 6.10 x86_64 - MySQL 5.1.
+
+### 1.9.0 - Unreleased
+
+- Updates source image to [1.9.0](https://github.com/jdeathe/centos-ssh/releases/tag/1.9.0).
 
 ### 1.8.5 - 2018-08-07
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # CentOS-6, MySQL 5.1
 # 
 # =============================================================================
-FROM jdeathe/centos-ssh:1.8.4
+FROM jdeathe/centos-ssh:1.9.0
 
 # -----------------------------------------------------------------------------
 # Install MySQL
@@ -102,7 +102,7 @@ jdeathe/centos-ssh-mysql:${RELEASE_VERSION} \
 	org.deathe.license="MIT" \
 	org.deathe.vendor="jdeathe" \
 	org.deathe.url="https://github.com/jdeathe/centos-ssh-mysql" \
-	org.deathe.description="CentOS-6 6.9 x86_64 - MySQL 5.1."
+	org.deathe.description="CentOS-6 6.10 x86_64 - MySQL 5.1."
 
 HEALTHCHECK \
 	--interval=1s \

--- a/README-short.txt
+++ b/README-short.txt
@@ -1,1 +1,1 @@
-CentOS-6 6.9 x86_64 - MySQL.
+CentOS-6 6.10 x86_64 - MySQL.

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@ centos-ssh-mysql
 ================
 
 Docker Image including:
-- CentOS-6 6.9 x86_64, MySQL 5.1.
-- CentOS-7 7.4.1708 x86_64, MySQL 5.7 Community Server.
+- CentOS-6 6.10 x86_64, MySQL 5.1.
+- CentOS-7 7.5.1804 x86_64, MySQL 5.7 Community Server.
 
 Includes Automated password generation and an option for custom initialisation SQL. Supports custom configuration via environment variables.
 


### PR DESCRIPTION
CLOSES #185

- Updates source image to [1.9.0](https://github.com/jdeathe/centos-ssh/releases/tag/1.9.0).