### PR TITLE
CLOSES #231: Updates source image to 2.5.1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,13 @@ CentOS-7 7.5.1804 x86_64 - MySQL 5.7 Community Server.
 
 ### 2.2.0 - Unreleased
 
-- Updates source image to [2.5.0](https://github.com/jdeathe/centos-ssh/releases/tag/2.5.0).
+- Updates source image to [2.5.1](https://github.com/jdeathe/centos-ssh/releases/tag/2.5.1).
 - Updates and restructures Dockerfile.
 - Updates container naming conventions and readability of `Makefile`.
 - Updates `mysql-community-server` package to 5.7.25-1.
+- Updates Dockerfile with combined ADD to reduce layer count in final image.
 - Fixes issue with unexpected published port in run templates when `DOCKER_PORT_MAP_TCP_3306` is set to an empty string or 0.
+- Fixes binary paths in systemd unit files for compatibility with both EL and Ubuntu hosts.
 - Adds placeholder replacement of `RELEASE_VERSION` docker argument to systemd service unit template.
 - Adds consideration for event lag into test cases for unhealthy health_status events.
 - Adds port incrementation to Makefile's run template for container names with an instance suffix.
@@ -21,6 +23,8 @@ CentOS-7 7.5.1804 x86_64 - MySQL 5.7 Community Server.
 - Adds docker-compose configuration example.
 - Adds improved logging output.
 - Adds improved root password configuration.
+- Adds improvement to pull logic in systemd unit install template.
+- Adds `SSH_AUTOSTART_SUPERVISOR_STDOUT` with a value "false", disabling startup of `supervisor_stdout`.
 - Removes use of `/etc/services-config` paths.
 - Removes code from configuration file `/etc/mysqld-bootstrap.conf`.
 - Removes X-Fleet section from etcd register template unit-file.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jdeathe/centos-ssh:2.5.0
+FROM jdeathe/centos-ssh:2.5.1
 
 ARG RELEASE_VERSION="2.1.1"
 
@@ -35,12 +35,7 @@ RUN { printf -- \
 # ------------------------------------------------------------------------------
 # Copy files into place
 # ------------------------------------------------------------------------------
-ADD src/etc \
-	/etc/
-ADD src/opt/scmi \
-	/opt/scmi/
-ADD src/usr \
-	/usr/
+ADD src /
 
 # ------------------------------------------------------------------------------
 # Provisioning
@@ -72,7 +67,8 @@ ENV MYSQL_AUTOSTART_MYSQLD_BOOTSTRAP="true" \
 	MYSQL_USER_PASSWORD="" \
 	MYSQL_USER_PASSWORD_HASHED="false" \
 	SSH_AUTOSTART_SSHD="false" \
-	SSH_AUTOSTART_SSHD_BOOTSTRAP="false"
+	SSH_AUTOSTART_SSHD_BOOTSTRAP="false" \
+	SSH_AUTOSTART_SUPERVISOR_STDOUT="false"
 
 # ------------------------------------------------------------------------------
 # Set image metadata

--- a/src/etc/systemd/system/centos-ssh-mysql.register@.service
+++ b/src/etc/systemd/system/centos-ssh-mysql.register@.service
@@ -112,11 +112,9 @@ ExecStart=/bin/bash -c \
             ${REGISTER_KEY_ROOT}/ports/tcp/3306 \
           &> /dev/null; \
         then \
-          printf -- 'set
-'; \
+          printf -- 'set\n'; \
         else \
-          printf -- 'update
-'; \
+          printf -- 'update\n'; \
         fi) \
         ${REGISTER_KEY_ROOT}/ports/tcp/3306 \
         \"$(/usr/bin/docker port \
@@ -134,11 +132,9 @@ ExecStart=/bin/bash -c \
           ${REGISTER_KEY_ROOT}/hostname \
         &> /dev/null; \
       then \
-        printf -- 'set
-'; \
+        printf -- 'set\n'; \
       else \
-        printf -- 'update
-'; \
+        printf -- 'update\n'; \
       fi) \
       ${REGISTER_KEY_ROOT}/hostname \
       %H \

--- a/src/etc/systemd/system/centos-ssh-mysql.register@.service
+++ b/src/etc/systemd/system/centos-ssh-mysql.register@.service
@@ -35,6 +35,7 @@
 #
 # To uninstall:
 #     sudo systemctl disable -f {service-unit-instance-name}
+#     sudo systemctl daemon-reload
 #     sudo rm /etc/systemd/system/{service-unit-template-name}
 #     sudo systemctl daemon-reload
 # ------------------------------------------------------------------------------
@@ -86,7 +87,7 @@ ExecStart=/bin/bash -c \
         \"$(/usr/bin/docker port \
             {{SERVICE_UNIT_NAME}}.%i \
             3306 \
-          | /usr/bin/sed 's~^[0-9.]*:~~' \
+          | /bin/sed 's~^[0-9.]*:~~' \
         )\" \
         --ttl ${REGISTER_TTL} 2> /dev/null; \
     fi; \
@@ -111,15 +112,17 @@ ExecStart=/bin/bash -c \
             ${REGISTER_KEY_ROOT}/ports/tcp/3306 \
           &> /dev/null; \
         then \
-          echo set; \
+          printf -- 'set
+'; \
         else \
-          echo update; \
+          printf -- 'update
+'; \
         fi) \
         ${REGISTER_KEY_ROOT}/ports/tcp/3306 \
         \"$(/usr/bin/docker port \
             {{SERVICE_UNIT_NAME}}.%i \
             3306 \
-          | /usr/bin/sed 's~^[0-9.]*:~~' \
+          | /bin/sed 's~^[0-9.]*:~~' \
         )\" \
         --ttl ${REGISTER_TTL}; \
     fi; \
@@ -131,9 +134,11 @@ ExecStart=/bin/bash -c \
           ${REGISTER_KEY_ROOT}/hostname \
         &> /dev/null; \
       then \
-        echo set; \
+        printf -- 'set
+'; \
       else \
-        echo update; \
+        printf -- 'update
+'; \
       fi) \
       ${REGISTER_KEY_ROOT}/hostname \
       %H \

--- a/src/etc/systemd/system/centos-ssh-mysql@.service
+++ b/src/etc/systemd/system/centos-ssh-mysql@.service
@@ -26,7 +26,8 @@
 #     sudo systemctl enable -f {service-unit-instance-name}
 #
 # Start using:
-#     sudo systemctl [start|stop|restart|kill|status] {service-unit-instance-name}
+#     sudo systemctl [start|stop|restart|kill|status] \
+#       {service-unit-instance-name}
 #
 # Debugging:
 #     sudo systemctl status {service-unit-instance-name}
@@ -34,6 +35,7 @@
 #
 # To uninstall:
 #     sudo systemctl disable -f {service-unit-instance-name}
+#     sudo systemctl daemon-reload
 #     sudo systemctl stop {service-unit-instance-name}
 #     sudo rm /etc/systemd/system/{service-unit-template-name}
 #     sudo docker rm -f {service-unit-long-name}
@@ -66,20 +68,12 @@ Environment="MYSQL_USER_PASSWORD_HASHED=false"
 
 # Initialisation: Load image from local storage if available, otherwise pull.
 ExecStartPre=/bin/bash -c \
-  "if [[ -z $( \
-      if [[ -n $(/usr/bin/docker images -q \
-          ${DOCKER_USER}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG} \
-        ) ]]; \
-      then \
-        echo $(/usr/bin/docker images -q \
-          ${DOCKER_USER}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG} \
-        ); \
-      else \
-        echo $(/usr/bin/docker images -q \
-          docker.io/${DOCKER_USER}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG} \
-        ); \
-      fi; \
-    ) ]]; \
+  "if [[ -z \"$(/usr/bin/docker images -q \
+      ${DOCKER_USER}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG} \
+    )\" ]] \
+    && [[ -z \"$(/usr/bin/docker images -q \
+      docker.io/${DOCKER_USER}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG} \
+    )\" ]]; \
   then \
     if [[ -f ${DOCKER_IMAGE_PACKAGE_PATH}/${DOCKER_USER}/${DOCKER_IMAGE_NAME}.${DOCKER_IMAGE_TAG}.tar.xz ]]; \
     then \
@@ -138,27 +132,27 @@ ExecStart=/bin/bash -c \
     --env \"MYSQL_USER_PASSWORD_HASHED=${MYSQL_USER_PASSWORD_HASHED}\" \
     $(if [[ ${DOCKER_PORT_MAP_TCP_3306} != NULL ]]; \
     then \
-      if /usr/bin/grep -qE \
+      if /bin/grep -qE \
           '^([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}:)?[1-9][0-9]*$' \
           <<< \"${DOCKER_PORT_MAP_TCP_3306}\"; \
-        && /usr/bin/grep -qE \
+        && /bin/grep -qE \
           '^.+\.[0-9]+(\.[0-9]+)?$' \
-          <<< "${DOCKER_NAME}"
+          <<< %p.%i; \
       then \
         printf -- '--publish %%s%%s:3306' \
           $(\
-            /usr/bin/grep -o \
+            /bin/grep -o \
               '^[0-9\.]*:' \
               <<< \"${DOCKER_PORT_MAP_TCP_3306}\" \
           ) \
           $(( \
             $(\
-              /usr/bin/grep -oE \
+              /bin/grep -oE \
                 '[0-9]+$' \
                 <<< \"${DOCKER_PORT_MAP_TCP_3306}\" \
             ) \
             + $(\
-              /usr/bin/grep -oE \
+              /bin/grep -oE \
                 '^[0-9]+' \
                 <<< %i \
             ) \


### PR DESCRIPTION
CLOSES #231

- Updates source image to [2.5.1](https://github.com/jdeathe/centos-ssh/releases/tag/2.5.1).
- Updates Dockerfile with combined ADD to reduce layer count in final image.
- Fixes binary paths in systemd unit files for compatibility with both EL and Ubuntu hosts.
- Adds improvement to pull logic in systemd unit install template.
- Adds `SSH_AUTOSTART_SUPERVISOR_STDOUT` with a value "false", disabling startup of `supervisor_stdout`.